### PR TITLE
Revert "more readable exception handling _connect_tcp()"

### DIFF
--- a/mpd.py
+++ b/mpd.py
@@ -395,10 +395,10 @@ class MPDClient():
                 err = e
                 if sock is not None:
                     sock.close()
+        if err is not None:
+            raise err
         else:
             raise ConnectionError("getaddrinfo returns an empty list")
-
-        raise err
 
     def connect(self, host, port):
         if self._sock is not None:

--- a/test.py
+++ b/test.py
@@ -33,7 +33,7 @@ class TestMPDClient(unittest.TestCase):
             self.client.connect(MPD_HOST, MPD_PORT)
             self.idleclient.connect(MPD_HOST, MPD_PORT)
             self.commands = self.client.commands()
-        except (mpd.ConnectionError, SocketError) as e:
+        except SocketError as e:
             raise Exception("Can't connect mpd! Start it or check the configuration: %s" % e)
         if MPD_PASSW != None:
             try:
@@ -128,12 +128,6 @@ class TestMPDClient(unittest.TestCase):
         self.assertIsNone(self.client.unsubscribe("monty"))
         channels = self.client.channels()
         self.assertNotIn("monty", channels)
-
-    def test_connection_error(self):
-        client2 = mpd.MPDClient()
-        with self.assertRaises(mpd.ConnectionError) as cm:
-            # should never return getaddrinfo
-            client2.connect("255.255.255.255", 6600)
 
     def test_commands_list(self):
         """


### PR DESCRIPTION
This reverts commit da8cb1ae4610c848047dc91856aa25c29d8c6b16.

It turned out that da8cb1 actually changed the API of python-mpd: if an error
occurred while connecting to the MPD server, MPDClient._connect_tcp() would always
return 'ConnectionError("getaddrinfo returns an empty list"), even if getaddrinfo()
actually returned something.

I have no idea how to make getaddrinfo() returns nothing, so it's hard to test at
the moment.

Conflicts:

```
test.py
```
