### PR TITLE
logging: log MPD commands called

### DIFF
--- a/mpd.py
+++ b/mpd.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-mpd2.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import sys
 import socket
 from collections import Callable
@@ -168,6 +169,7 @@ _commands = {
 class MPDClient(object):
     def __init__(self, use_unicode=False):
         self.iterate = False
+        self.logger = logging.getLogger("mpd.MPDClient")
         self.use_unicode = use_unicode
         self._reset()
 
@@ -223,6 +225,10 @@ class MPDClient(object):
         parts = [command]
         for arg in args:
             parts.append('"%s"' % escape(encode_str(arg)))
+
+        self.logger.isEnabledFor(logging.DEBUG):
+            # Minimize logging cost if the logging is not activated.
+            self.logger.debug("Calling MPD %s%r", command, args)
         self._write_line(" ".join(parts))
 
     def _read_line(self):
@@ -418,6 +424,8 @@ class MPDClient(object):
             raise ConnectionError("getaddrinfo returns an empty list")
 
     def connect(self, host, port, timeout=None):
+        self.logger.debug("Calling MPD connect(%r, %r, timeout=%r)", host,
+                          port, timeout)
         if self._sock is not None:
             raise ConnectionError("Already connected")
         if host.startswith("/"):
@@ -433,6 +441,7 @@ class MPDClient(object):
             raise
 
     def disconnect(self):
+        self.logger.debug("Calling MPD disconnect()")
         if not self._rfile is None:
             self._rfile.close()
         if not self._wfile is None:


### PR DESCRIPTION
This was in Sonata before, but I believe it makes sense to have it here.

If the application doesn't use logging, it shouldn't do anything, but if it does, well, one can see what's happening.
