### PR TITLE
unicode: lower-level encoder/decoder to deal with non-ASCII characters

### DIFF
--- a/mpd.py
+++ b/mpd.py
@@ -465,8 +465,16 @@ class MPDClient(object):
             self._sock = self._connect_unix(host)
         else:
             self._sock = self._connect_tcp(host, port)
-        self._rfile = self._sock.makefile("r")
-        self._wfile = self._sock.makefile("w")
+
+        if IS_PYTHON2:
+            self._rfile = self._sock.makefile("r")
+            self._wfile = self._sock.makefile("w")
+        else:
+            # Force UTF-8 encoding, since this is dependant from the LC_CTYPE
+            # locale.
+            self._rfile = self._sock.makefile("r", encoding="utf-8")
+            self._wfile = self._sock.makefile("w", encoding="utf-8")
+
         try:
             self._hello()
         except:


### PR DESCRIPTION
While trying to deal with multani/sonata#25, I got the problem described below.

Note that I'm not sure this is the correct way to deal with this and that I didn't write test (yet, since I can't get the current test running successfully on both Python 2 & 3 in a reliable way).

On python3, socket.socket().makefile() returns a file-like object which
converts bytes to string (which is cool), using the system encoding as
default encoding/decoding method (which is not so cool).
So, if our MPD library contains non-ASCII characters and your locale is C,
_rfile.readline() will fail since it will try to decode the bytes to Unicode
using an ASCII decoder.

This patch enforces the communication with MPD to UTF-8 on Python 3, and
try to deal with it if use_unicode is True with Python 2.

Note that wrapping the file-like sockets with codecs.EncodedFile() would be
better, but it gets stuck while reading lines (incompatibility when wrapping
sockets?)
