### PR TITLE
Add version information to module

### DIFF
--- a/mpd.py
+++ b/mpd.py
@@ -21,6 +21,7 @@ import socket
 import warnings
 from collections import Callable
 
+VERSION = (0, 4, 6)
 HELLO_PREFIX = "OK MPD "
 ERROR_PREFIX = "ACK "
 SUCCESS = "OK"


### PR DESCRIPTION
For application developers it is convenient to programatically obtain the version of the python-mpd2 library. That way the application knows which features it can rely on, which bugs may need to be worked around etc. 

My patch adds a three-tuple for major, minor and patch level. I don't insist on this representation, however, if there are arguments for a different one.
