### PR TITLE
Added note about async commands to command reference doc

### DIFF
--- a/doc/topics/commands.rst
+++ b/doc/topics/commands.rst
@@ -2,6 +2,13 @@
 Commands
 ========
 
+.. note::
+
+    Each command have a *send_* and a *fetch_* variant, which allows to send a
+    MPD command and then fetch the result later. See :ref:`getting-started` for
+    examples and more information.
+
+
 Querying MPD's status
 ---------------------
 

--- a/doc/topics/getting-started.rst
+++ b/doc/topics/getting-started.rst
@@ -1,3 +1,5 @@
+.. _getting-started:
+
 Using the client library
 ------------------------
 


### PR DESCRIPTION
I think this would clarify things:

![screenshot](http://tmp.dbrgn.ch/screenshots/20140202_120241.png)
