### PR TITLE
Allow to call the method disconnect, same when any connection is alive

### DIFF
--- a/mpd.py
+++ b/mpd.py
@@ -532,9 +532,11 @@ class MPDClient(object):
 
     def disconnect(self):
         logger.info("Calling MPD disconnect()")
-        if self._rfile is not None:
+        if (self._rfile is not None
+                and not isinstance(self._rfile, _NotConnected)):
             self._rfile.close()
-        if self._wfile is not None:
+        if (self._wfile is not None
+                and not isinstance(self._wfile, _NotConnected)):
             self._wfile.close()
         if self._sock is not None:
             self._sock.close()

--- a/mpd.py
+++ b/mpd.py
@@ -532,11 +532,11 @@ class MPDClient(object):
 
     def disconnect(self):
         logger.info("Calling MPD disconnect()")
-        if not self._rfile is None:
+        if self._rfile is not None:
             self._rfile.close()
-        if not self._wfile is None:
+        if self._wfile is not None:
             self._wfile.close()
-        if not self._sock is None:
+        if self._sock is not None:
             self._sock.close()
         self._reset()
 


### PR DESCRIPTION
I think that the disconnect method should accept being called without raising an connection error.
Example, in the case where an user want called this method in the block ``finally``, same when any connection is alive. :smiley: 
    