### PR TITLE
Overhaul package, add optional twisted based client. Replaces #76

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,19 +3,20 @@
 # Packages
 *.egg
 *.egg-info
-/dist
-/build
-/eggs
-/parts
-/bin
-/var
-/sdist
-/develop-eggs
+/.eggs/
+/dist/
+/build/
+/eggs/
+/parts/
+/bin/
+/var/
+/sdist/
+/develop-eggs/
+/lib/
+/lib64/
+/include/
+/local/
 /.installed.cfg
-/lib
-/lib64
-/include
-/local
 
 # Installer logs
 /pip-selfcheck.json
@@ -25,6 +26,7 @@
 /.coverage
 /.tox
 /nosetests.xml
+/coverage_html/
 
 # Sphinx docs
 /doc/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ python:
   - "3.5"
   - "pypy"
 
-script: python mpd_test.py
+script: python -m unittest mpd.tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ python:
   - "3.5"
   - "pypy"
 
+install:
+  - pip install .
+
 script: python -m unittest mpd.tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ python:
   - "pypy"
 
 install:
-  - pip install .
+  - pip install Twisted
 
 script: python -m unittest mpd.tests

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,11 @@ Changes in v0.6.0 (unreleased)
 ------------------------------
 
 * Use @property and @property.setter for MPDClient.timeout
+* Add support for twisted
+* deprecate send_* and fetch_* variants of MPD commands:
+  consider using twisted instead, in future asyncio support will be added
 * Introduce MPDClientBase class which provides common MPD communication related
   helpers. Used as base for synchronous and asynchronous clients
-* Introduce lookup_func which also searches on base classes for hooking
-  commands
 
 
 Changes in v0.5.5

--- a/examples/twisted.py
+++ b/examples/twisted.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+from mpd import MPDProtocol
+from twisted.internet import protocol
+from twisted.internet import reactor
+
+
+class MPDApp(object):
+    # Example application which deals with MPD
+
+    def __init__(self, protocol):
+        self.protocol = protocol
+
+    def __call__(self, result):
+        # idle result callback
+        print(result)
+
+        def status_success(result):
+            # status query success
+            print(result)
+
+        def status_error(result):
+            # status query failure
+            print(result)
+
+        # query player status
+        self.protocol.status()\
+            .addCallback(status_success)\
+            .addErrback(status_error)
+
+
+class MPDClientFactory(protocol.ClientFactory):
+    protocol = MPDProtocol
+
+    def buildProtocol(self, addr):
+        print("Create MPD protocol")
+        protocol = self.protocol()
+        protocol.factory = self
+        protocol.idle_result = MPDApp(protocol)
+        return protocol
+
+    def clientConnectionFailed(self, connector, reason):
+        print("Connection failed - goodbye!")
+        reactor.stop()
+    
+    def clientConnectionLost(self, connector, reason):
+        print("Connection lost - goodbye!")
+        reactor.stop()
+
+
+if __name__ == '__main__':
+    factory = MPDClientFactory()
+    reactor.connectTCP("localhost", 6600, factory)
+    reactor.run()

--- a/examples/twisted_example.py
+++ b/examples/twisted_example.py
@@ -12,15 +12,15 @@ class MPDApp(object):
 
     def __call__(self, result):
         # idle result callback
-        print(result)
+        print('Subsystems: {}'.format(list(result)))
 
         def status_success(result):
             # status query success
-            print(result)
+            print('Status success: {}'.format(result))
 
         def status_error(result):
             # status query failure
-            print(result)
+            print('Status error: {}'.format(result))
 
         # query player status
         self.protocol.status()\
@@ -32,22 +32,23 @@ class MPDClientFactory(protocol.ClientFactory):
     protocol = MPDProtocol
 
     def buildProtocol(self, addr):
-        print("Create MPD protocol")
+        print('Create MPD protocol')
         protocol = self.protocol()
         protocol.factory = self
         protocol.idle_result = MPDApp(protocol)
         return protocol
 
     def clientConnectionFailed(self, connector, reason):
-        print("Connection failed - goodbye!: %s" % reason)
+        print('Connection failed - goodbye!: {}'.format(reason))
         reactor.stop()
 
     def clientConnectionLost(self, connector, reason):
-        print("Connection lost - goodbye!: %s" % reason)
-        reactor.stop()
+        print('Connection lost - goodbye!: {}'.format(reason))
+        if reactor.running:
+            reactor.stop()
 
 
 if __name__ == '__main__':
     factory = MPDClientFactory()
-    reactor.connectTCP("localhost", 6600, factory)
+    reactor.connectTCP('localhost', 6600, factory)
     reactor.run()

--- a/examples/twisted_example.py
+++ b/examples/twisted_example.py
@@ -39,11 +39,11 @@ class MPDClientFactory(protocol.ClientFactory):
         return protocol
 
     def clientConnectionFailed(self, connector, reason):
-        print("Connection failed - goodbye!")
+        print("Connection failed - goodbye!: %s" % reason)
         reactor.stop()
-    
+
     def clientConnectionLost(self, connector, reason):
-        print("Connection lost - goodbye!")
+        print("Connection lost - goodbye!: %s" % reason)
         reactor.stop()
 
 

--- a/mpd/__init__.py
+++ b/mpd/__init__.py
@@ -1,0 +1,29 @@
+# python-mpd2: Python MPD client library
+#
+# Copyright (C) 2008-2010  J. Alexander Treuman <jat@spatialrift.net>
+# Copyright (C) 2012  J. Thalheim <jthalheim@gmail.com>
+# Copyright (C) 2016  Robert Niederreiter <rnix@squarewave.at>
+#
+# python-mpd2 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python-mpd2 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with python-mpd2.  If not, see <http://www.gnu.org/licenses/>.
+
+from mpd.base import CommandError
+from mpd.base import CommandListError
+from mpd.base import ConnectionError
+from mpd.base import IteratingError
+from mpd.base import MPDClient
+from mpd.base import MPDError
+from mpd.base import PendingCommandError
+from mpd.base import ProtocolError
+from mpd.base import VERSION
+

--- a/mpd/__init__.py
+++ b/mpd/__init__.py
@@ -27,3 +27,7 @@ from mpd.base import PendingCommandError
 from mpd.base import ProtocolError
 from mpd.base import VERSION
 
+try:
+    from mpd.twisted import MPDProtocol
+except ImportError:
+    pass

--- a/mpd/__init__.py
+++ b/mpd/__init__.py
@@ -30,4 +30,6 @@ from mpd.base import VERSION
 try:
     from mpd.twisted import MPDProtocol
 except ImportError:
-    pass
+    class MPDProtocol:
+        def __init__():
+            raise "No twisted module found"

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -289,12 +289,12 @@ class MPDClientBase(object):
     @mpd_commands(
         'add', 'addtagid', 'clear', 'clearerror', 'cleartagid', 'consume',
         'crossfade', 'delete', 'deleteid', 'disableoutput', 'enableoutput',
-        'findadd', 'load', 'mixrampdb', 'mixrampdelay', 'mount', 'move', 
-        'moveid', 'next', 'password', 'pause', 'ping', 'play', 'playid', 
+        'findadd', 'load', 'mixrampdb', 'mixrampdelay', 'mount', 'move',
+        'moveid', 'next', 'password', 'pause', 'ping', 'play', 'playid',
         'playlistadd', 'playlistclear', 'playlistdelete', 'playlistmove',
         'previous', 'prio', 'prioid', 'random', 'rangeid', 'rename', 'repeat',
         'replay_gain_mode', 'rm', 'save', 'searchadd', 'searchaddpl', 'seek',
-        'seekcur', 'seekid', 'sendmessage', 'setvol', 'shuffle', 'single', 
+        'seekcur', 'seekid', 'sendmessage', 'setvol', 'shuffle', 'single',
         'sticker delete', 'sticker set', 'stop', 'subscribe', 'swap', 'swapid',
         'toggleoutput', 'umount', 'unsubscribe')
     def _parse_nothing(self, lines):
@@ -627,11 +627,11 @@ class MPDClient(MPDClientBase):
 
     def disconnect(self):
         logger.info("Calling MPD disconnect()")
-        if (self._rfile is not None
-                and not isinstance(self._rfile, _NotConnected)):
+        if (self._rfile is not None and
+                not isinstance(self._rfile, _NotConnected)):
             self._rfile.close()
-        if (self._wfile is not None
-                and not isinstance(self._wfile, _NotConnected)):
+        if (self._wfile is not None and
+                not isinstance(self._wfile, _NotConnected)):
             self._wfile.close()
         if self._sock is not None:
             self._sock.close()

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -1,6 +1,8 @@
 # python-mpd2: Python MPD client library
+#
 # Copyright (C) 2008-2010  J. Alexander Treuman <jat@spatialrift.net>
 # Copyright (C) 2012  J. Thalheim <jthalheim@gmail.com>
+# Copyright (C) 2016  Robert Niederreiter <rnix@squarewave.at>
 #
 # python-mpd2 is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -411,6 +411,8 @@ class MPDClient(MPDClientBase):
         self._wfile = _NotConnected()
 
     def _send(self, command, args, retval):
+        warnings.warn("The 'send_%s' is deprecated in favor of asynchronous api" % command, DeprecationWarning)
+
         if self._command_list is not None:
             raise CommandListError(
                 "Cannot use send_{} in a command list".format(command))
@@ -419,6 +421,8 @@ class MPDClient(MPDClientBase):
             self._pending.append(command)
 
     def _fetch(self, command, args, retval):
+        warnings.warn("The 'fetch_%s' is deprecated in favor of asynchronous api" % command, DeprecationWarning)
+
         if self._command_list is not None:
             raise CommandListError(
                 "Cannot use fetch_{} in a command list".format(command))

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -17,17 +17,27 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with python-mpd2.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
-import sys
-import socket
-import warnings
 from collections import Callable
+import logging
+import socket
+import sys
+import warnings
+
+
+###############################################################################
+# constants
+###############################################################################
 
 VERSION = (0, 6, 0)
 HELLO_PREFIX = "OK MPD "
 ERROR_PREFIX = "ACK "
 SUCCESS = "OK"
 NEXT = "list_OK"
+
+
+###############################################################################
+# utils
+###############################################################################
 
 IS_PYTHON2 = sys.version_info < (3, 0)
 if IS_PYTHON2:
@@ -40,10 +50,19 @@ if IS_PYTHON2:
         else:
             return (unicode(s)).encode("utf-8")
 else:
-
     def decode_str(s):
         return s
+
     encode_str = str
+
+
+def escape(text):
+    return text.replace("\\", "\\\\").replace('"', '\\"')
+
+
+###############################################################################
+# logging
+###############################################################################
 
 try:
     from logging import NullHandler
@@ -52,9 +71,14 @@ except ImportError:  # NullHandler was introduced in python2.7
         def emit(self, record):
             pass
 
+
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
 
+
+###############################################################################
+# exceptions
+###############################################################################
 
 class MPDError(Exception):
     pass
@@ -84,162 +108,99 @@ class IteratingError(MPDError):
     pass
 
 
-class _NotConnected(object):
-    def __getattr__(self, attr):
-        return self._dummy
+###############################################################################
+# command registration
+###############################################################################
 
-    def _dummy(*args):
-        raise ConnectionError("Not connected")
+class mpd_commands(object):
+    """Decorator for registering MPD commands with it's corresponding result
+    callback.
+    """
 
-_commands = {
-    # Status Commands
-    "clearerror":         "_fetch_nothing",
-    "currentsong":        "_fetch_object",
-    "idle":               "_fetch_idle",
-    "status":             "_fetch_object",
-    "stats":              "_fetch_object",
-    # Playback Option Commands
-    "consume":            "_fetch_nothing",
-    "crossfade":          "_fetch_nothing",
-    "mixrampdb":          "_fetch_nothing",
-    "mixrampdelay":       "_fetch_nothing",
-    "random":             "_fetch_nothing",
-    "repeat":             "_fetch_nothing",
-    "setvol":             "_fetch_nothing",
-    "single":             "_fetch_nothing",
-    "replay_gain_mode":   "_fetch_nothing",
-    "replay_gain_status": "_fetch_item",
-    # Playback Control Commands
-    "next":               "_fetch_nothing",
-    "pause":              "_fetch_nothing",
-    "play":               "_fetch_nothing",
-    "playid":             "_fetch_nothing",
-    "previous":           "_fetch_nothing",
-    "seek":               "_fetch_nothing",
-    "seekid":             "_fetch_nothing",
-    "seekcur":            "_fetch_nothing",
-    "stop":               "_fetch_nothing",
-    # Playlist Commands
-    "add":                "_fetch_nothing",
-    "addid":              "_fetch_item",
-    "addtagid":           "_fetch_nothing",
-    "cleartagid":         "_fetch_nothing",
-    "clear":              "_fetch_nothing",
-    "delete":             "_fetch_nothing",
-    "deleteid":           "_fetch_nothing",
-    "move":               "_fetch_nothing",
-    "moveid":             "_fetch_nothing",
-    "playlist":           "_fetch_playlist",
-    "playlistfind":       "_fetch_songs",
-    "playlistid":         "_fetch_songs",
-    "playlistinfo":       "_fetch_songs",
-    "playlistsearch":     "_fetch_songs",
-    "plchanges":          "_fetch_songs",
-    "plchangesposid":     "_fetch_changes",
-    "prio":               "_fetch_nothing",
-    "prioid":             "_fetch_nothing",
-    "rangeid":            "_fetch_nothing",
-    "shuffle":            "_fetch_nothing",
-    "swap":               "_fetch_nothing",
-    "swapid":             "_fetch_nothing",
-    # Stored Playlist Commands
-    "listplaylist":       "_fetch_list",
-    "listplaylistinfo":   "_fetch_songs",
-    "listplaylists":      "_fetch_playlists",
-    "load":               "_fetch_nothing",
-    "playlistadd":        "_fetch_nothing",
-    "playlistclear":      "_fetch_nothing",
-    "playlistdelete":     "_fetch_nothing",
-    "playlistmove":       "_fetch_nothing",
-    "rename":             "_fetch_nothing",
-    "rm":                 "_fetch_nothing",
-    "save":               "_fetch_nothing",
-    # Database Commands
-    "count":              "_fetch_object",
-    "find":               "_fetch_songs",
-    "findadd":            "_fetch_nothing",
-    "list":               "_fetch_list",
-    "listall":            "_fetch_database",
-    "listallinfo":        "_fetch_database",
-    "listfiles":          "_fetch_database",
-    "lsinfo":             "_fetch_database",
-    "readcomments":       "_fetch_object",
-    "search":             "_fetch_songs",
-    "searchadd":          "_fetch_nothing",
-    "searchaddpl":        "_fetch_nothing",
-    "update":             "_fetch_item",
-    "rescan":             "_fetch_item",
-    # Mounts and neighbors
-    "mount":              "_fetch_nothing",
-    "umount":             "_fetch_nothing",
-    "listmounts":         "_fetch_mounts",
-    "listneighbors":      "_fetch_neighbors",
-    # Sticker Commands
-    "sticker get":        "_fetch_sticker",
-    "sticker set":        "_fetch_nothing",
-    "sticker delete":     "_fetch_nothing",
-    "sticker list":       "_fetch_stickers",
-    "sticker find":       "_fetch_songs",
-    # Connection Commands
-    "close":              None,
-    "kill":               None,
-    "password":           "_fetch_nothing",
-    "ping":               "_fetch_nothing",
-    # Audio Output Commands
-    "disableoutput":      "_fetch_nothing",
-    "enableoutput":       "_fetch_nothing",
-    "toggleoutput":       "_fetch_nothing",
-    "outputs":            "_fetch_outputs",
-    # Reflection Commands
-    "config":             "_fetch_item",
-    "commands":           "_fetch_list",
-    "notcommands":        "_fetch_list",
-    "tagtypes":           "_fetch_list",
-    "urlhandlers":        "_fetch_list",
-    "decoders":           "_fetch_plugins",
-    # Client To Client
-    "subscribe":          "_fetch_nothing",
-    "unsubscribe":        "_fetch_nothing",
-    "channels":           "_fetch_list",
-    "readmessages":       "_fetch_messages",
-    "sendmessage":        "_fetch_nothing",
-}
+    def __init__(self, *commands):
+        self.commands = commands
 
+    def __call__(self, ob):
+        ob.mpd_commands = self.commands
+        return ob
+
+
+def mpd_command_provider(cls):
+    """Decorator hooking up registered MPD commands to concrete client
+    implementation.
+
+    A class using this decorator must inherit from ``MPDClientBase`` and
+    implement it's ``add_command`` function.
+    """
+    def collect(cls, callbacks=dict()):
+        """Collect MPD command callbacks from given class.
+
+        Searches class __dict__ on given class and all it's bases for functions
+        which have been decorated with @mpd_commands and returns a dict
+        containing callback name as keys and
+        (callback, callback implementing class) tuples as values.
+        """
+        for name, ob in cls.__dict__.items():
+            if hasattr(ob, "mpd_commands") and name not in callbacks:
+                callbacks[name] = (ob, cls)
+        for base in cls.__bases__:
+            callbacks = collect(base, callbacks)
+        return callbacks
+
+    for name, value in collect(cls).items():
+        callback, from_ = value
+        for command in callback.mpd_commands:
+            cls.add_command(command, callback)
+    return cls
+
+
+class Noop(object):
+    """An instance of this class represents a MPD command callback which
+    does nothing.
+    """
+    mpd_commands = None
+
+
+###############################################################################
+# abstract base client
+###############################################################################
 
 class MPDClientBase(object):
+    """Abstract MPD client.
+
+    This class defines a general client contract, provides MPD protocol parsers
+    and defines all available MPD commands and it's corresponding result
+    parsing callbacks. There might be the need of overriding some callbacks on
+    subclasses.
+    """
 
     def __init__(self, use_unicode=False):
         self.iterate = False
         self.use_unicode = use_unicode
         self._reset()
 
-    def disconnect(self):
+    @classmethod
+    def add_command(cls, name, callback):
         raise NotImplementedError(
-            "MPDClientBase does not implement disconnect")
+            'Abstract ``MPDClientBase`` does not implement ``add_command``')
+
+    def noidle(self):
+        raise NotImplementedError(
+            'Abstract ``MPDClientBase`` does not implement ``noidle``')
+
+    def command_list_ok_begin(self):
+        raise NotImplementedError(
+            'Abstract ``MPDClientBase`` does not implement '
+            '``command_list_ok_begin``')
+
+    def command_list_end(self):
+        raise NotImplementedError(
+            'Abstract ``MPDClientBase`` does not implement '
+            '``command_list_end``')
 
     def _reset(self):
         self.mpd_version = None
-        self._pending = []
         self._command_list = None
-
-    def _parse_line(self, line):
-        if self.use_unicode:
-            line = decode_str(line)
-        if not line.endswith("\n"):
-            self.disconnect()
-            raise ConnectionError("Connection lost while reading line")
-        line = line.rstrip("\n")
-        if line.startswith(ERROR_PREFIX):
-            error = line[len(ERROR_PREFIX):].strip()
-            raise CommandError(error)
-        if self._command_list is not None:
-            if line == NEXT:
-                return
-            if line == SUCCESS:
-                raise ProtocolError("Got unexpected '{}'".format(SUCCESS))
-        elif line == SUCCESS:
-            return
-        return line
 
     def _parse_pair(self, line, separator):
         if line is None:
@@ -252,20 +213,6 @@ class MPDClientBase(object):
     def _parse_pairs(self, lines, separator=": "):
         for line in lines:
             yield self._parse_pair(line, separator)
-
-    def _parse_list(self, lines):
-        seen = None
-        for key, value in self._parse_pairs(lines):
-            if key != seen:
-                if seen is not None:
-                    raise ProtocolError(
-                        "Expected key '{}', got '{}'".format(seen, key))
-                seen = key
-            yield value
-
-    def _parse_playlist(self, lines):
-        for key, value in self._parse_pairs(lines, ":"):
-            yield value
 
     def _parse_objects(self, lines, delimiters=[]):
         obj = {}
@@ -285,7 +232,7 @@ class MPDClientBase(object):
         if obj:
             yield obj
 
-    def _parse_stickers(self, lines):
+    def _parse_raw_stickers(self, lines):
         for key, sticker in self._parse_pairs(lines):
             value = sticker.split('=', 1)
             if len(value) < 2:
@@ -293,16 +240,171 @@ class MPDClientBase(object):
                     "Could not parse sticker: {}".format(repr(sticker)))
             yield tuple(value)
 
+    NOOP = mpd_commands('close', 'kill')(Noop())
 
+    @mpd_commands('plchangesposid')
+    def _parse_changes(self, lines):
+        return self._parse_objects(lines, ["cpos"])
+
+    @mpd_commands('listall', 'listallinfo', 'listfiles', 'lsinfo')
+    def _parse_database(self, lines):
+        return self._parse_objects(lines, ["file", "directory", "playlist"])
+
+    @mpd_commands('idle')
+    def _parse_idle(self, lines):
+        return self._parse_list(lines)
+
+    @mpd_commands('addid', 'config', 'replay_gain_status', 'rescan', 'update')
+    def _parse_item(self, lines):
+        pairs = list(self._parse_pairs(lines))
+        if len(pairs) != 1:
+            return
+        return pairs[0][1]
+
+    @mpd_commands(
+        'channels', 'commands', 'list', 'listplaylist', 'notcommands',
+        'tagtypes', 'urlhandlers')
+    def _parse_list(self, lines):
+        seen = None
+        for key, value in self._parse_pairs(lines):
+            if key != seen:
+                if seen is not None:
+                    raise ProtocolError(
+                        "Expected key '{}', got '{}'".format(seen, key))
+                seen = key
+            yield value
+
+    @mpd_commands('readmessages')
+    def _parse_messages(self, lines):
+        return self._parse_objects(lines, ["channel"])
+
+    @mpd_commands('listmounts')
+    def _parse_mounts(self, lines):
+        return self._parse_objects(lines, ["mount"])
+
+    @mpd_commands('listneighbors')
+    def _parse_neighbors(self, lines):
+        return self._parse_objects(lines, ["neighbor"])
+
+    @mpd_commands(
+        'add', 'addtagid', 'clear', 'clearerror', 'cleartagid', 'consume',
+        'crossfade', 'delete', 'deleteid', 'disableoutput', 'enableoutput',
+        'findadd', 'load', 'mixrampdb', 'mixrampdelay', 'mount', 'move', 
+        'moveid', 'next', 'password', 'pause', 'ping', 'play', 'playid', 
+        'playlistadd', 'playlistclear', 'playlistdelete', 'playlistmove',
+        'previous', 'prio', 'prioid', 'random', 'rangeid', 'rename', 'repeat',
+        'replay_gain_mode', 'rm', 'save', 'searchadd', 'searchaddpl', 'seek',
+        'seekcur', 'seekid', 'sendmessage', 'setvol', 'shuffle', 'single', 
+        'sticker delete', 'sticker set', 'stop', 'subscribe', 'swap', 'swapid',
+        'toggleoutput', 'umount', 'unsubscribe')
+    def _parse_nothing(self, lines):
+        for line in lines:
+            raise ProtocolError(
+                "Got unexpected return value: '{}'".format(', '.join(lines)))
+
+    @mpd_commands('count', 'currentsong', 'readcomments', 'stats', 'status')
+    def _parse_object(self, lines):
+        objs = list(self._parse_objects(lines))
+        if not objs:
+            return {}
+        return objs[0]
+
+    @mpd_commands('outputs')
+    def _parse_outputs(self, lines):
+        return self._parse_objects(lines, ["outputid"])
+
+    @mpd_commands('playlist')
+    def _parse_playlist(self, lines):
+        for key, value in self._parse_pairs(lines, ":"):
+            yield value
+
+    @mpd_commands('listplaylists')
+    def _parse_playlists(self, lines):
+        return self._parse_objects(lines, ["playlist"])
+
+    @mpd_commands('decoders')
+    def _parse_plugins(self, lines):
+        return self._parse_objects(lines, ["plugin"])
+
+    @mpd_commands(
+        'find', 'listplaylistinfo', 'playlistfind', 'playlistid',
+        'playlistinfo', 'playlistsearch', 'plchanges', 'search', 'sticker find')
+    def _parse_songs(self, lines):
+        return self._parse_objects(lines, ["file"])
+
+    @mpd_commands('sticker get')
+    def _parse_sticker(self, lines):
+        key, value = list(self._parse_raw_stickers(lines))[0]
+        return value
+
+    @mpd_commands('sticker list')
+    def _parse_stickers(self, lines):
+        return dict(self._parse_raw_stickers(lines))
+
+
+###############################################################################
+# sync client
+###############################################################################
+
+def _create_callback(self, function, wrap_result):
+    """Create MPD command related response callback.
+    """
+    if not isinstance(function, Callable):
+        return None
+    def command_callback():
+        # command result callback expects response from MPD as iterable lines,
+        # thus read available lines from socket
+        res = function(self, self._read_lines())
+        # wrap result in iterator helper if desired
+        if wrap_result:
+            res = self._wrap_iterator(res)
+        return res
+    return command_callback
+
+
+def _create_command(wrapper, name, return_value, wrap_result):
+    """Create MPD command related function.
+    """
+    def mpd_command(self, *args):
+        callback = _create_callback(self, return_value, wrap_result)
+        return wrapper(self, name, args, callback)
+    return mpd_command
+
+
+class _NotConnected(object):
+    def __getattr__(self, attr):
+        return self._dummy
+
+    def _dummy(*args):
+        raise ConnectionError("Not connected")
+
+
+@mpd_command_provider
 class MPDClient(MPDClientBase):
     idletimeout = None
     _timeout = None
+    _wrap_iterator_parsers = [
+        MPDClientBase._parse_list,
+        MPDClientBase._parse_playlist,
+        MPDClientBase._parse_changes,
+        MPDClientBase._parse_songs,
+        MPDClientBase._parse_mounts,
+        MPDClientBase._parse_neighbors,
+        MPDClientBase._parse_playlists,
+        MPDClientBase._parse_database,
+        MPDClientBase._parse_messages,
+        MPDClientBase._parse_outputs,
+        MPDClientBase._parse_plugins
+    ]
+    if IS_PYTHON2:
+        _wrap_iterator_parsers = [f.__func__ for f in _wrap_iterator_parsers]
 
     def __init__(self, use_unicode=False):
         super(MPDClient, self).__init__(use_unicode=use_unicode)
 
     def _reset(self):
         super(MPDClient, self)._reset()
+        self._pending = []
         self._iterating = False
         self._sock = None
         self._rfile = _NotConnected()
@@ -374,13 +476,28 @@ class MPDClient(MPDClientBase):
                 logger.debug("Calling MPD password(******)")
             else:
                 logger.debug("Calling MPD %s%r", command, args)
-        self._write_line(" ".join(parts))
-
-    ##################
-    # response helpers
+        cmd = " ".join(parts)
+        self._write_line(cmd)
 
     def _read_line(self):
-        return self._parse_line(self._rfile.readline())
+        line = self._rfile.readline()
+        if self.use_unicode:
+            line = decode_str(line)
+        if not line.endswith("\n"):
+            self.disconnect()
+            raise ConnectionError("Connection lost while reading line")
+        line = line.rstrip("\n")
+        if line.startswith(ERROR_PREFIX):
+            error = line[len(ERROR_PREFIX):].strip()
+            raise CommandError(error)
+        if self._command_list is not None:
+            if line == NEXT:
+                return
+            if line == SUCCESS:
+                raise ProtocolError("Got unexpected '{}'".format(SUCCESS))
+        elif line == SUCCESS:
+            return
+        return line
 
     def _read_lines(self):
         line = self._read_line()
@@ -388,31 +505,13 @@ class MPDClient(MPDClientBase):
             yield line
             line = self._read_line()
 
-    def _read_pair(self, separator):
-        return self._parse_pair(self._read_line(), separator)
-
-    def _read_pairs(self, separator=": "):
-        return self._parse_pairs(self._read_lines(), separator)
-
-    def _read_list(self):
-        return self._parse_list(self._read_lines())
-
-    def _read_playlist(self):
-        return self._parse_playlist(self._read_lines())
-
-    def _read_objects(self, delimiters=[]):
-        return self._parse_objects(self._read_lines(), delimiters)
-
-    def _read_stickers(self):
-        return self._parse_stickers(self._read_lines())
-
     def _read_command_list(self):
         try:
             for retval in self._command_list:
                 yield retval()
         finally:
             self._command_list = None
-        self._fetch_nothing()
+        self._parse_nothing(self._read_lines())
 
     def _iterator_wrapper(self, iterator):
         try:
@@ -426,83 +525,6 @@ class MPDClient(MPDClientBase):
             return list(iterator)
         self._iterating = True
         return self._iterator_wrapper(iterator)
-
-    ####################
-    # response callbacks
-
-    def _fetch_nothing(self):
-        line = self._read_line()
-        if line is not None:
-            raise ProtocolError(
-                "Got unexpected return value: '{}'".format(line))
-
-    def _fetch_item(self):
-        pairs = list(self._read_pairs())
-        if len(pairs) != 1:
-            return
-        return pairs[0][1]
-
-    def _fetch_sticker(self):
-        # Either we get one or we get an error while reading the line
-        key, value = list(self._read_stickers())[0]
-        return value
-
-    def _fetch_stickers(self):
-        return dict(self._read_stickers())
-
-    def _fetch_list(self):
-        return self._wrap_iterator(self._read_list())
-
-    def _fetch_playlist(self):
-        return self._wrap_iterator(self._read_playlist())
-
-    def _fetch_object(self):
-        objs = list(self._read_objects())
-        if not objs:
-            return {}
-        return objs[0]
-
-    def _fetch_objects(self, delimiters):
-        return self._wrap_iterator(self._read_objects(delimiters))
-
-    def _fetch_changes(self):
-        return self._fetch_objects(["cpos"])
-
-    def _fetch_idle(self):
-        self._sock.settimeout(self.idletimeout)
-        ret = self._fetch_list()
-        self._sock.settimeout(self._timeout)
-        return ret
-
-    def _fetch_songs(self):
-        return self._fetch_objects(["file"])
-
-    def _fetch_mounts(self):
-        return self._fetch_objects(["mount"])
-
-    def _fetch_neighbors(self):
-        return self._fetch_objects(["neighbor"])
-
-    def _fetch_playlists(self):
-        return self._fetch_objects(["playlist"])
-
-    def _fetch_database(self):
-        return self._fetch_objects(["file", "directory", "playlist"])
-
-    def _fetch_messages(self):
-        return self._fetch_objects(["channel"])
-
-    def _fetch_outputs(self):
-        return self._fetch_objects(["outputid"])
-
-    def _fetch_plugins(self):
-        return self._fetch_objects(["plugin"])
-
-    def _fetch_command_list(self):
-        return self._wrap_iterator(self._read_command_list())
-
-    # end response callbacks
-    ########################
 
     def _hello(self):
         line = self._rfile.readline()
@@ -548,6 +570,13 @@ class MPDClient(MPDClientBase):
             raise err
         else:
             raise ConnectionError("getaddrinfo returns an empty list")
+
+    @mpd_commands('idle')
+    def _parse_idle(self, lines):
+        self._sock.settimeout(self.idletimeout)
+        ret = self._wrap_iterator(self._parse_list(lines))
+        self._sock.settimeout(self._timeout)
+        return ret
 
     @property
     def timeout(self):
@@ -619,7 +648,7 @@ class MPDClient(MPDClientBase):
             raise CommandError(msg)
         del self._pending[0]
         self._write_command("noidle")
-        return self._fetch_list()
+        return self._wrap_iterator(self._parse_list(self._read_lines()))
 
     def command_list_ok_begin(self):
         if self._command_list is not None:
@@ -638,19 +667,20 @@ class MPDClient(MPDClientBase):
         if self._iterating:
             raise IteratingError("Already iterating over a command list")
         self._write_command("command_list_end")
-        return self._fetch_command_list()
+        return self._wrap_iterator(self._read_command_list())
 
     @classmethod
     def add_command(cls, name, callback):
-        method = new_function(cls._execute, name, callback)
-        send_method = new_function(cls._send, name, callback)
-        fetch_method = new_function(cls._fetch, name, callback)
+        wrap_result = callback in cls._wrap_iterator_parsers
+        method = _create_command(cls._execute, name, callback, wrap_result)
+        send_method = _create_command(cls._send, name, callback, wrap_result)
+        fetch_method = _create_command(cls._fetch, name, callback, wrap_result)
         # create new mpd commands as function in three flavors:
         # normal, with "send_"-prefix and with "fetch_"-prefix
         escaped_name = name.replace(" ", "_")
         setattr(cls, escaped_name, method)
-        setattr(cls, "send_"+escaped_name, send_method)
-        setattr(cls, "fetch_"+escaped_name, fetch_method)
+        setattr(cls, "send_" + escaped_name, send_method)
+        setattr(cls, "fetch_" + escaped_name, fetch_method)
 
     @classmethod
     def remove_command(cls, name):
@@ -661,43 +691,5 @@ class MPDClient(MPDClientBase):
         delattr(cls, str(name))
         delattr(cls, str("send_" + name))
         delattr(cls, str("fetch_" + name))
-
-
-def bound_decorator(self, function):
-    """Bind decorator to self.
-    """
-    if not isinstance(function, Callable):
-        return None
-    def decorator(*args, **kwargs):
-        return function(self, *args, **kwargs)
-    return decorator
-
-
-def new_function(wrapper, name, return_value):
-    def decorator(self, *args):
-        return wrapper(self, name, args, bound_decorator(self, return_value))
-    return decorator
-
-
-def lookup_func(cls, name):
-    func = None
-    if name in cls.__dict__:
-        func = cls.__dict__[name]
-    else:
-        for base in cls.__bases__:
-            func = lookup_func(base, name)
-            if func is not None:
-                break
-    return func
-
-
-for key, value in _commands.items():
-    return_value = lookup_func(MPDClient, value)
-    MPDClient.add_command(key, return_value)
-
-
-def escape(text):
-    return text.replace("\\", "\\\\").replace('"', '\\"')
-
 
 # vim: set expandtab shiftwidth=4 softtabstop=4 textwidth=79:

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -732,14 +732,6 @@ class TestMPDProtocol(unittest.TestCase):
         self.protocol.lineReceived(b'OK')
 
     def test_command_list_failure(self):
-        """
-        OK MPD 0.18.0
-        command_list_ok_begin
-        load "Foo"
-        play
-        command_list_end
-        ACK [50@0] {load} No such playlist
-        """
         self.init_protocol(default_idle=False)
 
         def load_command_error(result):
@@ -800,6 +792,65 @@ class TestMPDProtocol(unittest.TestCase):
         self.protocol.lineReceived(b'OK')
         self.assertEqual([b'idle\n'], self.protocol.transport.written)
 
+    def test_command_list_failure_when_default_idle(self):
+        self.init_protocol()
+        self.protocol.lineReceived(b'OK MPD 0.18.0')
+
+        def load_command_error(result):
+            self.assertIsInstance(result, Failure)
+            self.assertEqual(
+                result.getErrorMessage(),
+                '[50@0] {load} No such playlist'
+            )
+
+        def command_list_general_error(result):
+            self.assertIsInstance(result, Failure)
+            self.assertEqual(
+                result.getErrorMessage(),
+                'An earlier command failed.'
+            )
+
+        self.protocol.command_list_ok_begin()
+        self.protocol.load('Foo').addErrback(load_command_error)
+        self.protocol.play().addErrback(command_list_general_error)
+        self.protocol.command_list_end().addErrback(load_command_error)
+        self.assertEqual(
+            [
+                b'idle\n',
+                b'noidle\n',
+                b'command_list_ok_begin\n',
+                b'load "Foo"\n',
+                b'play\n',
+                b'command_list_end\n',
+            ],
+            self.protocol.transport.written
+        )
+        self.protocol.transport.clear()
+        self.protocol.lineReceived(b'OK')
+        self.protocol.lineReceived(b'ACK [50@0] {load} No such playlist')
+        self.assertEqual([b'idle\n'], self.protocol.transport.written)
+
+    def test_command_list_item_is_generator(self):
+        self.init_protocol(default_idle=False)
+
+        def success(result):
+            self.assertEqual(result, [[
+                u"Weezer - Say It Ain't So.mp3",
+                u'Dire Straits - Walk of Life.mp3',
+                u'01 - Love Delicatessen.mp3',
+                u"Guns N' Roses - Paradise City.mp3"
+            ]])
+
+        self.protocol.command_list_ok_begin()
+        self.protocol.listplaylist('Foo')
+        self.protocol.command_list_end().addCallback(success)
+        self.protocol.lineReceived(b'file: Weezer - Say It Ain\'t So.mp3')
+        self.protocol.lineReceived(b'file: Dire Straits - Walk of Life.mp3')
+        self.protocol.lineReceived(b'file: 01 - Love Delicatessen.mp3')
+        self.protocol.lineReceived(b'file: Guns N\' Roses - Paradise City.mp3')
+        self.protocol.lineReceived(b'list_OK')
+        self.protocol.lineReceived(b'OK')
+
     def test_already_in_command_list(self):
         self.init_protocol(default_idle=False)
         self.protocol.command_list_ok_begin()
@@ -814,6 +865,22 @@ class TestMPDProtocol(unittest.TestCase):
             mpd.CommandListError,
             lambda: self.protocol.command_list_end()
         )
+
+    def test_invalid_command_in_command_list(self):
+        self.init_protocol(default_idle=False)
+        self.protocol.command_list_ok_begin()
+        self.assertRaises(
+            mpd.CommandListError,
+            lambda: self.protocol.kill()
+        )
+
+    def test_close(self):
+        self.init_protocol(default_idle=False)
+
+        def success(result):
+            self.assertEqual(result, None)
+
+        self.protocol.close().addCallback(success)
 
 
 if __name__ == '__main__':

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -39,7 +39,7 @@ class TestMPDClient(unittest.TestCase):
     longMessage = True
 
     def setUp(self):
-        self.socket_patch = mock.patch("mpd.socket")
+        self.socket_patch = mock.patch("mpd.base.socket")
         self.socket_mock = self.socket_patch.start()
         self.socket_mock.getaddrinfo.return_value = [range(5)]
 

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -2,11 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import itertools
+import mpd
 import sys
 import types
 import warnings
-
-import mpd
 
 try:
     # is required for python2.6
@@ -69,6 +68,20 @@ class TestMPDClient(unittest.TestCase):
     def assertMPDReceived(self, *lines):
         self.client._wfile.write.assert_called_with(*lines)
 
+    def test_abstract_functions(self):
+        MPDClientBase = mpd.base.MPDClientBase
+        self.assertRaises(
+            NotImplementedError,
+            lambda: MPDClientBase.add_command('command_name', lambda x: x))
+        client = MPDClientBase()
+        self.assertRaises(NotImplementedError, lambda: client.noidle())
+        self.assertRaises(
+            NotImplementedError,
+            lambda: client.command_list_ok_begin())
+        self.assertRaises(
+            NotImplementedError,
+            lambda: client.command_list_end())
+
     def test_metaclass_commands(self):
         # just some random functions
         self.assertTrue(hasattr(self.client, "commands"))
@@ -89,7 +102,7 @@ class TestMPDClient(unittest.TestCase):
         self.assertIsInstance(song["track"], list)
         self.assertMPDReceived('currentsong\n')
 
-    def test_fetch_nothing(self):
+    def test_parse_nothing(self):
         self.MPDWillReturn('OK\n', 'OK\n')
 
         self.assertIsNone(self.client.ping())
@@ -98,17 +111,17 @@ class TestMPDClient(unittest.TestCase):
         self.assertIsNone(self.client.clearerror())
         self.assertMPDReceived('clearerror\n')
 
-    def test_fetch_list(self):
+    def test_parse_list(self):
         self.MPDWillReturn('OK\n')
 
         self.assertIsInstance(self.client.list("album"), list)
         self.assertMPDReceived('list "album"\n')
 
-    def test_fetch_item(self):
+    def test_parse_item(self):
         self.MPDWillReturn('updating_db: 42\n', 'OK\n')
         self.assertIsNotNone(self.client.update())
 
-    def test_fetch_object(self):
+    def test_parse_object(self):
         # XXX: _read_objects() doesn't wait for the final OK
         self.MPDWillReturn('volume: 63\n', 'OK\n')
         status = self.client.status()
@@ -121,7 +134,7 @@ class TestMPDClient(unittest.TestCase):
         self.assertMPDReceived('stats\n')
         self.assertIsInstance(stats, dict)
 
-    def test_fetch_songs(self):
+    def test_parse_songs(self):
         self.MPDWillReturn("file: my-song.ogg\n",
                            "Pos: 0\n",
                            "Id: 66\n",
@@ -217,7 +230,7 @@ class TestMPDClient(unittest.TestCase):
         self.MPDWillReturn("ACK awesome command\n")
 
         self.client.add_command("awesome command",
-                                mpd.MPDClient._fetch_nothing)
+                                mpd.MPDClient._parse_nothing)
         self.assertTrue(hasattr(self.client, "awesome_command"))
         self.assertTrue(hasattr(self.client, "send_awesome_command"))
         self.assertTrue(hasattr(self.client, "fetch_awesome_command"))
@@ -302,6 +315,7 @@ class TestMPDClient(unittest.TestCase):
         self.assertMPDReceived('close\n')
 
         # XXX: what are we testing here?
+        #      looks like reconnection test?
         self.client._reset()
         self.client.connect(TEST_MPD_HOST, TEST_MPD_PORT)
 
@@ -372,27 +386,139 @@ class TestMPDClient(unittest.TestCase):
             self.client.move((1, "garbage"), 2)
             self.assertMPDReceived('move "1:" "2"\n')
 
-    def test_read_stickers(self):
+    def test_parse_changes(self):
+        self.MPDWillReturn(
+            'cpos: 0\n',
+            'Id: 66\n',
+            'cpos: 1\n',
+            'Id: 67\n',
+            'cpos: 2\n',
+            'Id: 68\n',
+            'cpos: 3\n',
+            'Id: 69\n',
+            'cpos: 4\n',
+            'Id: 70\n',
+            'OK\n')
+        res = self.client.plchangesposid(0)
+        self.assertEqual([
+            {'cpos': '0', 'id': '66'},
+            {'cpos': '1', 'id': '67'},
+            {'cpos': '2', 'id': '68'},
+            {'cpos': '3', 'id': '69'},
+            {'cpos': '4', 'id': '70'}], res)
+
+    def test_parse_database(self):
+        self.MPDWillReturn(
+            'directory: foo\n',
+            'Last-Modified: 2014-01-23T16:42:46Z\n',
+            'file: bar.mp3\n',
+            'size: 59618802\n',
+            'Last-Modified: 2014-11-02T19:57:00Z\n',
+            'OK\n')
+        self.client.listfiles("/")
+
+    def test_parse_mounts(self):
+        self.MPDWillReturn(
+            'mount: \n',
+            'storage: /home/foo/music\n',
+            'mount: foo\n',
+            'storage: nfs://192.168.1.4/export/mp3\n',
+            'OK\n')
+        res = self.client.listmounts()
+        self.assertEqual([
+            {'mount': '', 'storage': '/home/foo/music'},
+            {'mount': 'foo', 'storage': 'nfs://192.168.1.4/export/mp3'}], res)
+
+    def test_parse_neighbors(self):
+        self.MPDWillReturn(
+            'neighbor: smb://FOO\n',
+            'name: FOO (Samba 4.1.11-Debian)\n',
+            'OK\n')
+        res = self.client.listneighbors()
+        self.assertEqual(
+            [{'name': 'FOO (Samba 4.1.11-Debian)', 'neighbor': 'smb://FOO'}],
+            res)
+
+    def test_parse_outputs(self):
+        self.MPDWillReturn(
+            'outputid: 0\n',
+            'outputname: My ALSA Device\n',
+            'outputenabled: 0\n',
+            'OK\n')
+        res = self.client.outputs()
+        self.assertEqual([{
+            'outputenabled': '0',
+            'outputid': '0',
+            'outputname': 'My ALSA Device'}], res)
+
+    def test_parse_playlist(self):
+        self.MPDWillReturn(
+            '0:file: Weezer - Say It Ain\'t So.mp3\n',
+            '1:file: Dire Straits - Walk of Life.mp3\n',
+            '2:file: 01 - Love Delicatessen.mp3\n',
+            '3:file: Guns N\' Roses - Paradise City.mp3\n',
+            '4:file: Nirvana - Lithium.mp3\n',
+            'OK\n')
+        res = self.client.playlist()
+        self.assertEqual([
+            "file: Weezer - Say It Ain't So.mp3",
+            'file: Dire Straits - Walk of Life.mp3',
+            'file: 01 - Love Delicatessen.mp3',
+            "file: Guns N' Roses - Paradise City.mp3",
+            'file: Nirvana - Lithium.mp3'], res)
+
+    def test_parse_playlists(self):
+        self.MPDWillReturn(
+            'playlist: Playlist\n',
+            'Last-Modified: 2016-08-13T10:55:56Z\n',
+            'OK\n')
+        res = self.client.listplaylists()
+        self.assertEqual([
+            {'last-modified': '2016-08-13T10:55:56Z', 'playlist': 'Playlist'}
+        ], res)
+
+    def test_parse_plugins(self):
+        self.MPDWillReturn(
+            'plugin: vorbis\n',
+            'suffix: ogg\n',
+            'suffix: oga\n',
+            'mime_type: application/ogg\n',
+            'mime_type: application/x-ogg\n',
+            'mime_type: audio/ogg\n',
+            'mime_type: audio/vorbis\n',
+            'mime_type: audio/vorbis+ogg\n',
+            'mime_type: audio/x-ogg\n',
+            'mime_type: audio/x-vorbis\n',
+            'mime_type: audio/x-vorbis+ogg\n',
+            'OK\n')
+        res = self.client.decoders()
+        self.assertEqual([{
+            'mime_type': [
+                'application/ogg',
+                'application/x-ogg',
+                'audio/ogg',
+                'audio/vorbis',
+                'audio/vorbis+ogg',
+                'audio/x-ogg',
+                'audio/x-vorbis',
+                'audio/x-vorbis+ogg'],
+            'plugin': 'vorbis',
+            'suffix': [
+                'ogg',
+                'oga']}], list(res))
+
+    def test_parse_raw_stickers(self):
         self.MPDWillReturn("sticker: foo=bar\n", "OK\n")
-        res = self.client._read_stickers()
+        res = self.client._parse_raw_stickers(self.client._read_lines())
         self.assertEqual([('foo', 'bar')], list(res))
 
         self.MPDWillReturn("sticker: foo=bar\n", "sticker: l=b\n", "OK\n")
-        res = self.client._read_stickers()
+        res = self.client._parse_raw_stickers(self.client._read_lines())
         self.assertEqual([('foo', 'bar'), ('l', 'b')], list(res))
 
-    def test_fetch_database(self):
-        self.MPDWillReturn('directory: foo\n',
-                           'Last-Modified: 2014-01-23T16:42:46Z\n',
-                           'file: bar.mp3\n',
-                           'size: 59618802\n',
-                           'Last-Modified: 2014-11-02T19:57:00Z\n',
-                           'OK\n')
-        self.client.listfiles("/")
-
-    def test_read_sticker_with_special_value(self):
+    def test_parse_raw_sticker_with_special_value(self):
         self.MPDWillReturn("sticker: foo==uv=vu\n", "OK\n")
-        res = self.client._read_stickers()
+        res = self.client._parse_raw_stickers(self.client._read_lines())
         self.assertEqual([('foo', '=uv=vu')], list(res))
 
     def test_parse_sticket_get_one(self):
@@ -414,6 +540,64 @@ class TestMPDClient(unittest.TestCase):
         self.MPDWillReturn("sticker: foo=bar\n", "OK\n")
         res = self.client.sticker_list('song', 'baz')
         self.assertEqual({'foo': 'bar'}, res)
+
+    def test_command_list(self):
+        self.MPDWillReturn(
+            'list_OK\n',
+            'list_OK\n',
+            'list_OK\n',
+            'list_OK\n',
+            'list_OK\n',
+            'volume: 100\n',
+            'repeat: 1\n',
+            'random: 1\n',
+            'single: 0\n',
+            'consume: 0\n',
+            'playlist: 68\n',
+            'playlistlength: 5\n',
+            'mixrampdb: 0.000000\n',
+            'state: play\n',
+            'xfade: 5\n',
+            'song: 0\n',
+            'songid: 56\n',
+            'time: 0:259\n',
+            'elapsed: 0.000\n',
+            'bitrate: 0\n',
+            'nextsong: 2\n',
+            'nextsongid: 58\n',
+            'list_OK\n',
+            'OK\n')
+        self.client.command_list_ok_begin()
+        self.client.clear()
+        self.client.load('Playlist')
+        self.client.random(1)
+        self.client.repeat(1)
+        self.client.play(0)
+        self.client.status()
+        res = self.client.command_list_end()
+        self.assertEqual(None, res[0])
+        self.assertEqual(None, res[1])
+        self.assertEqual(None, res[2])
+        self.assertEqual(None, res[3])
+        self.assertEqual(None, res[4])
+        self.assertEqual([
+            ('bitrate', '0'),
+            ('consume', '0'),
+            ('elapsed', '0.000'),
+            ('mixrampdb', '0.000000'),
+            ('nextsong', '2'),
+            ('nextsongid', '58'),
+            ('playlist', '68'),
+            ('playlistlength', '5'),
+            ('random', '1'),
+            ('repeat', '1'),
+            ('single', '0'),
+            ('song', '0'),
+            ('songid', '56'),
+            ('state', 'play'),
+            ('time', '0:259'),
+            ('volume', '100'),
+            ('xfade', '5')], sorted(res[5].items()))
 
 if __name__ == '__main__':
     unittest.main()

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from twisted.python.failure import Failure
 import itertools
 import mpd
 import sys
@@ -598,6 +599,221 @@ class TestMPDClient(unittest.TestCase):
             ('time', '0:259'),
             ('volume', '100'),
             ('xfade', '5')], sorted(res[5].items()))
+
+
+class MockTransport(object):
+
+    def __init__(self):
+        self.written = list()
+
+    def clear(self):
+        self.written = list()
+
+    def write(self, data):
+        self.written.append(data)
+
+
+class TestMPDProtocol(unittest.TestCase):
+
+    def init_protocol(self, default_idle=True, idle_result=None):
+        self.protocol = mpd.MPDProtocol(
+            default_idle=default_idle,
+            idle_result=idle_result
+        )
+        self.protocol.transport = MockTransport()
+
+    def test_success(self):
+        self.init_protocol(default_idle=False)
+
+        def success(result):
+            expected = {
+                'file': 'Dire Straits - Walk of Life.mp3',
+                'artist': 'Dire Straits',
+                'title': 'Walk of Life',
+                'genre': 'Rock/Pop',
+                'track': '3',
+                'album': 'Brothers in Arms',
+                'id': '13',
+                'last-modified': '2016-08-11T10:57:03Z',
+                'pos': '4',
+                'time': '253'
+            }
+            self.assertEqual(expected, result)
+
+        self.protocol.currentsong().addCallback(success)
+        self.assertEqual([b'currentsong\n'], self.protocol.transport.written)
+
+        for line in [b'file: Dire Straits - Walk of Life.mp3',
+                     b'Last-Modified: 2016-08-11T10:57:03Z',
+                     b'Time: 253',
+                     b'Artist: Dire Straits',
+                     b'Title: Walk of Life',
+                     b'Album: Brothers in Arms',
+                     b'Track: 3',
+                     b'Genre: Rock/Pop',
+                     b'Pos: 4',
+                     b'Id: 13',
+                     b'OK']:
+            self.protocol.lineReceived(line)
+
+    def test_failure(self):
+        self.init_protocol(default_idle=False)
+
+        def error(result):
+            self.assertIsInstance(result, Failure)
+            self.assertEqual(
+                result.getErrorMessage(),
+                '[50@0] {load} No such playlist'
+            )
+
+        self.protocol.load('Foo').addErrback(error)
+        self.assertEqual([b'load "Foo"\n'], self.protocol.transport.written)
+        self.protocol.lineReceived(b'ACK [50@0] {load} No such playlist')
+
+    def test_default_idle(self):
+
+        def idle_result(result):
+            self.assertEqual(list(result), ['player'])
+
+        self.init_protocol(idle_result=idle_result)
+        self.protocol.lineReceived(b'OK MPD 0.18.0')
+        self.assertEqual([b'idle\n'], self.protocol.transport.written)
+        self.protocol.transport.clear()
+        self.protocol.lineReceived(b'changed: player')
+        self.protocol.lineReceived(b'OK')
+        self.assertEqual(
+            [b'idle\n'],
+            self.protocol.transport.written
+        )
+
+    def test_noidle_when_default_idle(self):
+        self.init_protocol()
+        self.protocol.lineReceived(b'OK MPD 0.18.0')
+        self.protocol.pause()
+        self.protocol.lineReceived(b'OK')
+        self.protocol.lineReceived(b'OK')
+        self.assertEqual(
+            [b'idle\n', b'noidle\n', b'pause\n', b'idle\n'],
+            self.protocol.transport.written
+        )
+
+    def test_already_idle(self):
+        self.init_protocol(default_idle=False)
+        self.protocol.idle()
+        self.assertRaises(mpd.CommandError, lambda: self.protocol.idle())
+
+    def test_already_noidle(self):
+        self.init_protocol(default_idle=False)
+        self.assertRaises(mpd.CommandError, lambda: self.protocol.noidle())
+
+    def test_command_list(self):
+        self.init_protocol(default_idle=False)
+
+        def success(result):
+            self.assertEqual([None, None], result)
+
+        self.protocol.command_list_ok_begin()
+        self.protocol.play()
+        self.protocol.stop()
+        self.protocol.command_list_end().addCallback(success)
+        self.assertEqual(
+            [
+                b'command_list_ok_begin\n',
+                b'play\n',
+                b'stop\n',
+                b'command_list_end\n',
+            ],
+            self.protocol.transport.written
+        )
+        self.protocol.transport.written.clear()
+        self.protocol.lineReceived(b'list_OK')
+        self.protocol.lineReceived(b'list_OK')
+        self.protocol.lineReceived(b'OK')
+
+    def test_command_list_failure(self):
+        """
+        OK MPD 0.18.0
+        command_list_ok_begin
+        load "Foo"
+        play
+        command_list_end
+        ACK [50@0] {load} No such playlist
+        """
+        self.init_protocol(default_idle=False)
+
+        def load_command_error(result):
+            self.assertIsInstance(result, Failure)
+            self.assertEqual(
+                result.getErrorMessage(),
+                '[50@0] {load} No such playlist'
+            )
+
+        def command_list_general_error(result):
+            self.assertIsInstance(result, Failure)
+            self.assertEqual(
+                result.getErrorMessage(),
+                'An earlier command failed.'
+            )
+
+        self.protocol.command_list_ok_begin()
+        self.protocol.load('Foo').addErrback(load_command_error)
+        self.protocol.play().addErrback(command_list_general_error)
+        self.protocol.command_list_end().addErrback(load_command_error)
+        self.assertEqual(
+            [
+                b'command_list_ok_begin\n',
+                b'load "Foo"\n',
+                b'play\n',
+                b'command_list_end\n',
+            ],
+            self.protocol.transport.written
+        )
+        self.protocol.lineReceived(b'ACK [50@0] {load} No such playlist')
+
+    def test_command_list_when_default_idle(self):
+        self.init_protocol()
+        self.protocol.lineReceived(b'OK MPD 0.18.0')
+
+        def success(result):
+            self.assertEqual([None, None], result)
+
+        self.protocol.command_list_ok_begin()
+        self.protocol.play()
+        self.protocol.stop()
+        self.protocol.command_list_end().addCallback(success)
+        self.assertEqual(
+            [
+                b'idle\n',
+                b'noidle\n',
+                b'command_list_ok_begin\n',
+                b'play\n',
+                b'stop\n',
+                b'command_list_end\n',
+            ],
+            self.protocol.transport.written
+        )
+        self.protocol.transport.written.clear()
+        self.protocol.lineReceived(b'OK')
+        self.protocol.lineReceived(b'list_OK')
+        self.protocol.lineReceived(b'list_OK')
+        self.protocol.lineReceived(b'OK')
+        self.assertEqual([b'idle\n'], self.protocol.transport.written)
+
+    def test_already_in_command_list(self):
+        self.init_protocol(default_idle=False)
+        self.protocol.command_list_ok_begin()
+        self.assertRaises(
+            mpd.CommandListError,
+            lambda: self.protocol.command_list_ok_begin()
+        )
+
+    def test_not_in_command_list(self):
+        self.init_protocol(default_idle=False)
+        self.assertRaises(
+            mpd.CommandListError,
+            lambda: self.protocol.command_list_end()
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
 from twisted.python.failure import Failure
 import itertools
 import mpd
@@ -725,7 +726,7 @@ class TestMPDProtocol(unittest.TestCase):
             ],
             self.protocol.transport.written
         )
-        self.protocol.transport.written.clear()
+        self.protocol.transport.clear()
         self.protocol.lineReceived(b'list_OK')
         self.protocol.lineReceived(b'list_OK')
         self.protocol.lineReceived(b'OK')
@@ -792,7 +793,7 @@ class TestMPDProtocol(unittest.TestCase):
             ],
             self.protocol.transport.written
         )
-        self.protocol.transport.written.clear()
+        self.protocol.transport.clear()
         self.protocol.lineReceived(b'OK')
         self.protocol.lineReceived(b'list_OK')
         self.protocol.lineReceived(b'list_OK')

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -843,10 +843,10 @@ class TestMPDProtocol(unittest.TestCase):
 
         def success(result):
             self.assertEqual(result, [[
-                u"Weezer - Say It Ain't So.mp3",
-                u'Dire Straits - Walk of Life.mp3',
-                u'01 - Love Delicatessen.mp3',
-                u"Guns N' Roses - Paradise City.mp3"
+                "Weezer - Say It Ain't So.mp3",
+                'Dire Straits - Walk of Life.mp3',
+                '01 - Love Delicatessen.mp3',
+                "Guns N' Roses - Paradise City.mp3"
             ]])
 
         self.protocol.command_list_ok_begin()

--- a/mpd/twisted.py
+++ b/mpd/twisted.py
@@ -1,0 +1,212 @@
+# python-mpd2: Python MPD client library
+#
+# Copyright (C) 2008-2010  J. Alexander Treuman <jat@spatialrift.net>
+# Copyright (C) 2010  Jasper St. Pierre <jstpierre@mecheye.net>
+# Copyright (C) 2010-2011  Oliver Mader <b52@reaktor42.de>
+# Copyright (C) 2016  Robert Niederreiter <rnix@squarewave.at>
+#
+# python-mpd2 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# python-mpd2 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with python-mpd2.  If not, see <http://www.gnu.org/licenses/>.
+#
+# THIS MODULE IS EXPERIMENTAL. AS SOON AS IT IS CONSIDERED STABLE THIS NOTE
+# WILL BE REMOVED. PLEASE REPORT INCONSISTENCIES, BUGS AND IMPROVEMENTS AT
+# https://github.com/Mic92/python-mpd2/issues
+
+from __future__ import absolute_import
+from mpd.base import CommandError
+from mpd.base import CommandListError
+from mpd.base import ERROR_PREFIX
+from mpd.base import HELLO_PREFIX
+from mpd.base import MPDClientBase
+from mpd.base import NEXT
+from mpd.base import SUCCESS
+from mpd.base import logger
+from mpd.base import mpd_command_provider
+from mpd.base import mpd_commands
+from twisted.internet import defer
+from twisted.protocols import basic
+from types import GeneratorType
+
+
+def _create_command(wrapper, name, callback):
+    def mpd_command(self, *args):
+        def bound_callback(lines):
+            return callback(self, lines)
+        return wrapper(self, name, args, bound_callback)
+    return mpd_command
+
+
+@mpd_command_provider
+class MPDProtocol(basic.LineReceiver, MPDClientBase):
+    delimiter = "\n"
+
+    def __init__(self, default_idle=True, idle_result=None, use_unicode=False):
+        super(MPDProtocol, self).__init__(use_unicode=use_unicode)
+        # flag whether client should idle by default
+        self._default_idle = default_idle
+        self._idle_result = idle_result
+        self._reset()
+
+    def _reset(self):
+        super(MPDProtocol, self)._reset()
+        self.mpd_version = None
+        self._command_list = False
+        self._command_list_results = []
+        self._rcvd_lines = []
+        self._state = []
+        self._idle = False
+
+    @classmethod
+    def add_command(cls, name, callback):
+        # ignore commands which are implemented on class directly 
+        if getattr(cls, name, None) is not None:
+            return
+        # create command and hook it on class
+        func = _create_command(cls._execute, name, callback)
+        escaped_name = name.replace(" ", "_")
+        setattr(cls, escaped_name, func)
+
+    def lineReceived(self, line):
+        line = line.decode('utf-8')
+        command_list = self._state and isinstance(self._state[0], list)
+        state_list = self._state[0] if command_list else self._state
+        if line.startswith(HELLO_PREFIX):
+            self.mpd_version = line[len(HELLO_PREFIX):].strip()
+            # default state idle, enter idle
+            if self._default_idle:
+                self.idle().addCallback(self._dispatch_idle_result)
+        elif line.startswith(ERROR_PREFIX):
+            error = line[len(ERROR_PREFIX):].strip()
+            if command_list:
+                state_list[0].errback(CommandError(error))
+                for state in state_list[1:-1]:
+                    state.errback(
+                        CommandListError("An earlier command failed."))
+                state_list[-1].errback(CommandListError(error))
+                del self._state[0]
+                del self._command_list_results[0]
+            else:
+                state_list.pop(0).errback(CommandError(error))
+            # XXX: reset received lines here? 
+            self._continue_idle()
+        elif line == SUCCESS or (command_list and line == NEXT):
+            state_list.pop(0).callback(self._rcvd_lines[:])
+            self._rcvd_lines = []
+            if command_list and line == SUCCESS:
+                del self._state[0]
+            self._continue_idle()
+        else:
+            self._rcvd_lines.append(line)
+
+    def _execute(self, command, args, parser):
+        # close or kill command in command list not allowed
+        if self._command_list and not callable(parser):
+            msg = "{} not allowed in command list".format(command)
+            raise CommandListError(msg)
+        # default state idle and currently in idle state, trigger noidle
+        if self._default_idle and self._idle and command != "idle":
+            self.noidle().addCallback(self._dispatch_noidle_result)
+        # write command to MPD
+        self._write_command(command, args)
+        # create command related deferred
+        deferred = defer.Deferred()
+        # extend pending result queue
+        state = self._state[-1] if self._command_list else self._state
+        state.append(deferred)
+        # NOOP is for close and kill commands
+        if parser is not self.NOOP:
+            # attach command related result parser
+            deferred.addCallback(parser)
+            # command list, attach handler for collecting command list results
+            if self._command_list:
+                deferred.addCallback(self._parse_command_list_item)
+        return deferred
+
+    def _write_command(self, command, args=[]):
+        parts = [command]
+        parts += ['"{}"'.format(escape(arg.encode('utf-8')) \
+            if isinstance(arg, unicode) else str(arg)) for arg in args]
+        cmd = " ".join(parts)
+        self.sendLine(cmd)
+
+    def _parse_command_list_item(self, result):
+        # TODO: find a better way to do this
+        if type(result) == GeneratorType:
+            result = list(result)
+        self._command_list_results[0].append(result)
+        return result
+
+    def _parse_command_list_end(self, lines):
+        return self._command_list_results.pop(0)
+
+    @mpd_commands(
+        *MPDClientBase._parse_nothing.mpd_commands)
+    def _parse_nothing(self, lines):
+        return None
+
+    def _continue_idle(self):
+        if self._default_idle and not self._idle and not self._state:
+            self.idle().addCallback(self._dispatch_idle_result)
+
+    def _do_dispatch(self, result):
+        if self._idle_result:
+            self._idle_result(result)
+        else:
+            res = list(result)
+            msg = 'MPDProtocol: no idle callback defined: {}'.format(res)
+            logger.warning(msg)
+
+    def _dispatch_noidle_result(self, result):
+        self._do_dispatch(result)
+
+    def _dispatch_idle_result(self, result):
+        self._idle = False
+        self._do_dispatch(result)
+        self._continue_idle()
+
+    def idle(self):
+        if self._idle:
+            raise CommandError("Already in idle state")
+        self._idle = True
+        return self._execute('idle', [], self._parse_list)
+
+    def noidle(self):
+        if not self._idle:
+            raise CommandError("Not in idle state")
+        # delete first pending deferred, idle returns nothing when
+        # noidle gets called
+        self._state.pop(0)
+        self._idle = False
+        return self._execute('noidle', [], self._parse_list)
+
+    def command_list_ok_begin(self):
+        if self._command_list:
+            raise CommandListError("Already in command list")
+        if self._default_idle and self._idle:
+            self.noidle().addCallback(self._dispatch_noidle_result)
+        self._write_command("command_list_ok_begin")
+        self._command_list = True
+        self._command_list_results.append([])
+        self._state.append([])
+
+    def command_list_end(self):
+        if not self._command_list:
+            raise CommandListError("Not in command list")
+        self._write_command("command_list_end")
+        deferred = defer.Deferred()
+        deferred.addCallback(self._parse_command_list_end)
+        self._state[-1].append(deferred)
+        self._command_list = False
+        return deferred
+
+# vim: set expandtab shiftwidth=4 softtabstop=4 textwidth=79:

--- a/mpd/twisted.py
+++ b/mpd/twisted.py
@@ -69,7 +69,7 @@ class MPDProtocol(basic.LineReceiver, MPDClientBase):
 
     @classmethod
     def add_command(cls, name, callback):
-        # ignore commands which are implemented on class directly 
+        # ignore commands which are implemented on class directly
         if getattr(cls, name, None) is not None:
             return
         # create command and hook it on class
@@ -98,7 +98,7 @@ class MPDProtocol(basic.LineReceiver, MPDClientBase):
                 del self._command_list_results[0]
             else:
                 state_list.pop(0).errback(CommandError(error))
-            # XXX: reset received lines here? 
+            # XXX: reset received lines here?
             self._continue_idle()
         elif line == SUCCESS or (command_list and line == NEXT):
             state_list.pop(0).callback(self._rcvd_lines[:])
@@ -135,7 +135,7 @@ class MPDProtocol(basic.LineReceiver, MPDClientBase):
 
     def _write_command(self, command, args=[]):
         parts = [command]
-        parts += ['"{}"'.format(escape(arg.encode('utf-8')) \
+        parts += ['"{}"'.format(escape(arg.encode('utf-8'))
             if isinstance(arg, unicode) else str(arg)) for arg in args]
         cmd = " ".join(parts)
         self.sendLine(cmd)

--- a/mpd/twisted.py
+++ b/mpd/twisted.py
@@ -30,6 +30,7 @@ from mpd.base import HELLO_PREFIX
 from mpd.base import MPDClientBase
 from mpd.base import NEXT
 from mpd.base import SUCCESS
+from mpd.base import escape
 from mpd.base import logger
 from mpd.base import mpd_command_provider
 from mpd.base import mpd_commands

--- a/mpd/twisted.py
+++ b/mpd/twisted.py
@@ -51,8 +51,8 @@ def _create_command(wrapper, name, callback):
 class MPDProtocol(basic.LineReceiver, MPDClientBase):
     delimiter = "\n"
 
-    def __init__(self, default_idle=True, idle_result=None, use_unicode=False):
-        super(MPDProtocol, self).__init__(use_unicode=use_unicode)
+    def __init__(self, default_idle=True, idle_result=None):
+        super(MPDProtocol, self).__init__(use_unicode=True)
         # flag whether client should idle by default
         self._default_idle = default_idle
         self.idle_result = idle_result

--- a/mpd/twisted.py
+++ b/mpd/twisted.py
@@ -55,7 +55,7 @@ class MPDProtocol(basic.LineReceiver, MPDClientBase):
         super(MPDProtocol, self).__init__(use_unicode=use_unicode)
         # flag whether client should idle by default
         self._default_idle = default_idle
-        self._idle_result = idle_result
+        self.idle_result = idle_result
         self._reset()
 
     def _reset(self):
@@ -160,8 +160,8 @@ class MPDProtocol(basic.LineReceiver, MPDClientBase):
             self.idle().addCallback(self._dispatch_idle_result)
 
     def _do_dispatch(self, result):
-        if self._idle_result:
-            self._idle_result(result)
+        if self.idle_result:
+            self.idle_result(result)
         else:
             res = list(result)
             msg = 'MPDProtocol: no idle callback defined: {}'.format(res)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [sdist]
-formats=bztar,gztar,zip
+formats = bztar,gztar,zip
 
 [build_sphinx]
 source-dir = doc/
@@ -8,3 +8,6 @@ all_files = 1
 
 [upload_sphinx]
 upload-dir = doc/_build/html
+
+[easy_install]
+

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,19 @@
 #! /usr/bin/env python
 
-from distutils.core import setup
 from setuptools import Extension
+from setuptools import find_packages
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
-import sys,os
 import mpd
+import os
+import sys
+
 
 if sys.version_info[0] == 2:
     from io import open
+
+
+VERSION = ".".join(map(str, mpd.VERSION))
 
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",
@@ -23,6 +29,7 @@ CLASSIFIERS = [
 LICENSE = """\
 Copyright (C) 2008-2010  J. Alexander Treuman <jat@spatialrift.net>
 Copyright (C) 2012  J. Thalheim <joerg@higgsboson.tk>
+Copyright (C) 2016  Robert Niederreiter <rnix@squarewave.at>
 
 python-mpd2 is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -36,37 +43,43 @@ GNU Lesser General Public License for more details.  You should have received a 
 along with python-mpd2.  If not, see <http://www.gnu.org/licenses/>.\
 """
 
+
 class Tox(TestCommand):
+
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = []
         self.test_suite = True
+
     def run_tests(self):
         #import here, cause outside the eggs aren't loaded
         import tox
         errno = tox.cmdline(self.test_args)
         sys.exit(errno)
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__),  fname),  encoding="utf8").read()
 
-VERSION = ".".join(map(str, mpd.VERSION))
+def read(fname):
+    with open(os.path.join(os.path.dirname(__file__),  fname),
+              encoding="utf8") as fd:
+        return fd.read()
+
 
 setup(
     name="python-mpd2",
     version=VERSION,
     description="A Python MPD client library",
     long_description=read('README.rst'),
+    classifiers=CLASSIFIERS,
     author="J. Thalheim",
     author_email="jthalheim@gmail.com",
+    license="GNU Lesser General Public License v3 (LGPLv3)",
     url="https://github.com/Mic92/python-mpd2",
-    download_url="https://github.com/Mic92/python-mpd2/archive/v%s.zip" % VERSION,
-    py_modules=["mpd", "mpd_test"],
-    classifiers=CLASSIFIERS,
-    #license=LICENSE,
+    packages=find_packages(),
+    zip_safe=True,
     keywords=["mpd"],
+    test_suite="mpd.tests",
     tests_require=['tox'],
-    cmdclass = {'test': Tox},
+    cmdclass={'test': Tox}
 )
 
 # vim: set expandtab shiftwidth=4 softtabstop=4 textwidth=79:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class Tox(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
+        # import here, cause outside the eggs aren't loaded
         import tox
         errno = tox.cmdline(self.test_args)
         sys.exit(errno)

--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,12 @@ setup(
         'mock',
         'Twisted'
     ],
-    cmdclass={'test': Tox},
-    extras_require={'twisted':  ["twisted"]}
+    cmdclass={
+        'test': Tox
+    },
+    extras_require={
+        'twisted': ['Twisted']
+    }
 )
 
 # vim: set expandtab shiftwidth=4 softtabstop=4 textwidth=79:

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,11 @@ setup(
     zip_safe=True,
     keywords=["mpd"],
     test_suite="mpd.tests",
-    tests_require=['tox'],
+    tests_require=[
+        'tox',
+        'mock',
+        'Twisted'
+    ],
     cmdclass={'test': Tox},
     extras_require={'twisted':  ["twisted"]}
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
 
-from setuptools import Extension
 from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
@@ -79,7 +78,8 @@ setup(
     keywords=["mpd"],
     test_suite="mpd.tests",
     tests_require=['tox'],
-    cmdclass={'test': Tox}
+    cmdclass={'test': Tox},
+    extras_require={'twisted':  ["twisted"]}
 )
 
 # vim: set expandtab shiftwidth=4 softtabstop=4 textwidth=79:

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,17 @@ envlist = py26,py27,py32,py33,py34,py35,pypy
 
 [testenv]
 deps = mock
-commands = python mpd_test.py
+       coverage
+commands = coverage erase
+           coverage run mpd/tests.py
+           coverage report
+           coverage html -d coverage_html/{envname}
 
 [testenv:py26]
 deps = mock
        unittest2
-commands = python mpd_test.py
+       coverage
+commands = coverage erase
+           coverage run mpd/tests.py
+           coverage report
+           coverage html -d coverage_html/{envname}

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,9 @@ envlist = py26,py27,py32,py33,py34,py35,pypy
 [testenv]
 deps = mock
        coverage
+       Twisted
 commands = coverage erase
-           coverage run mpd/tests.py
+           coverage run -m unittest mpd.tests
            coverage report
            coverage html -d coverage_html/{envname}
 
@@ -13,7 +14,8 @@ commands = coverage erase
 deps = mock
        unittest2
        coverage
+       Twisted
 commands = coverage erase
-           coverage run mpd/tests.py
+           coverage run -m unittest mpd.tests
            coverage report
            coverage html -d coverage_html/{envname}


### PR DESCRIPTION
This pull request replaces #76.

* Create mpd package, move code from mpd.py to mpd/base.py
* Import public API in mpd/__init__.py
* Move more command result parsers to MPDClientBase
* Commands are now registered with mpd_commands decorator on MPDClientBase
* Add some more parser tests
* Add mpd/twisted.py module. Contains an MPDProtocol implementation. The installation of twisted is NOT mandatory, just results in an ImportError if you try to use it and twisted is not installed.
* Run tests with coverage

