### PR TITLE
New asyncio branch

### DIFF
--- a/examples/asyncio_example.py
+++ b/examples/asyncio_example.py
@@ -21,11 +21,33 @@ async def main():
     else:
         print("Status success:", status)
 
-    for x in await client.decoders():
-        print("sync decoder:", x)
+    print(list(await client.commands()))
 
-    async for x in client.decoders():
-        print("async decoder:", x)
+    import time
+    start = time.time()
+    for x in await client.listall():
+        print("sync:", x)
+        print("Time to first sync:", time.time() - start)
+        break
+
+    start = time.time()
+    async for x in client.listall():
+        print("async:", x)
+        print("Time to first async:", time.time() - start)
+        break
+
+    try:
+        await client.addid()
+    except Exception as e:
+        print("An erroneous command, as expected, raised:", e)
+
+    try:
+        async for x in client.plchangesposid():
+            print("Why does this work?")
+    except Exception as e:
+        print("An erroneous asynchronously looped command, as expected, raised:", e)
+
+    print("Idle result", list(await client.idle()))
 
 if __name__ == '__main__':
     asyncio.get_event_loop().run_until_complete(main())

--- a/examples/asyncio_example.py
+++ b/examples/asyncio_example.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from mpd.asyncio import MPDClient
+
+async def main():
+    print("Create MPD client")
+    client = MPDClient()
+    try:
+        await client.connect('localhost', 6600)
+    except Exception as e:
+        print("Connection failed:", e)
+        return
+
+    print("Connected to MPD version", client.mpd_version)
+
+    try:
+        status = await client.status()
+    except Exception as e:
+        print("Status error:", e)
+        return
+    else:
+        print("Status success:", status)
+
+    for x in await client.decoders():
+        print("sync decoder:", x)
+
+    async for x in client.decoders():
+        print("async decoder:", x)
+
+if __name__ == '__main__':
+    asyncio.get_event_loop().run_until_complete(main())

--- a/examples/asyncio_example.py
+++ b/examples/asyncio_example.py
@@ -47,7 +47,7 @@ async def main():
     except Exception as e:
         print("An erroneous asynchronously looped command, as expected, raised:", e)
 
-    print("Idle result", list(await client.idle()))
+    print("Idle result", await client.idle().get())
 
 if __name__ == '__main__':
     asyncio.get_event_loop().run_until_complete(main())

--- a/examples/asyncio_example.py
+++ b/examples/asyncio_example.py
@@ -47,7 +47,13 @@ async def main():
     except Exception as e:
         print("An erroneous asynchronously looped command, as expected, raised:", e)
 
-    print("Idle result", await client.idle().get())
+    i = 0
+    async for subsystem in client.idle():
+        print("Idle change in", subsystem)
+        i += 1
+        if i > 5:
+            print("Enough changes, quitting")
+            break
 
 if __name__ == '__main__':
     asyncio.get_event_loop().run_until_complete(main())

--- a/examples/summary.txt
+++ b/examples/summary.txt
@@ -22,3 +22,6 @@ ExampleStats  Get general information of your MPD server  2009-09-12
 ExampleStickers A command-line client for manipulating and querying stickers
 2010-12-18
 Examples  Some example scripts to show how to play with python-mpd  2010-12-18
+
+The asyncio_example.py shows how MPD can be used with the asyncio idioms; it
+requires at least Python 3.5 to run.

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -1,0 +1,124 @@
+import asyncio
+
+from mpd.base import HELLO_PREFIX, ERROR_PREFIX, SUCCESS
+from mpd.base import MPDClientBase
+from mpd.base import MPDClient as SyncMPDClient
+from mpd.base import ProtocolError, ConnectionError
+from mpd.base import mpd_command_provider
+
+@mpd_command_provider
+class MPDClient(MPDClientBase):
+    __run_task = None # doubles as indicator for being connected
+
+    async def connect(self, host, port=6600, loop=None):
+        self.__loop = loop
+
+        if '/' in host:
+            r, w = await asyncio.open_unic_connection(path, loop=loop)
+        else:
+            r, w = await asyncio.open_connection(host, port, loop=loop)
+        self.__rfile, self.__wfile = r, w
+
+        self.__commandqueue = asyncio.Queue(loop=loop)
+
+        await self.__hello()
+
+        self.__run_task = asyncio.Task(self.__run())
+
+    def disconnect(self):
+        self.__run_task.cancel()
+        self.__rfile = self.__wfile = None
+        self.__run_task = self.__commandqueue = None
+
+    async def __run(self):
+        while True:
+            command, args, callback, result = await self.__commandqueue.get()
+            self._write_command(command, args)
+            responselines = await self.__read_full_output()
+            try:
+                result.set_result(callback(self, responselines))
+            except Exception as e:
+                result.set_error(e)
+
+    # helper methods
+
+    async def __readline(self):
+        """Wrapper around .__rfile.readline that handles encoding"""
+        data = await self.__rfile.readline()
+        try:
+            return data.decode('utf8')
+        except UnicodeDecodeError:
+            self.disconnect()
+            raise ProtocolError("Invalid UTF8 received")
+
+    def __write(self, text):
+        """Wrapper around .__wfile.write that handles encoding."""
+        self.__wfile.write(text.encode('utf8'))
+
+    # copied stuff from base
+
+    async def __hello(self):
+        # not catching the timeout error, it's actually pretty adaequate
+        try:
+            line = await asyncio.wait_for(self.__readline(), timeout=5)
+        except asyncio.TimeoutError:
+            self.disconnect()
+            raise ConnectionError("No response from server while reading MPD hello")
+
+        # FIXME this is copied from base.MPDClient._hello
+        if not line.endswith("\n"):
+            self.disconnect()
+            raise ConnectionError("Connection lost while reading MPD hello")
+        line = line.rstrip("\n")
+        if not line.startswith(HELLO_PREFIX):
+            raise ProtocolError("Got invalid MPD hello: '{}'".format(line))
+        self.mpd_version = line[len(HELLO_PREFIX):].strip()
+
+    # FIXME this is just a wrapper for the below
+    def _write_line(self, text):
+        self.__write(text + "\n")
+    # FIXME this code should be sharable
+    _write_command = SyncMPDClient._write_command
+
+
+    async def __read_output_line(self):
+        """Kind of like SyncMPDClient._read_line"""
+        line = await self.__readline()
+        if not line.endswith("\n"):
+            self.disconnect()
+            raise ConnectionError("Connection lost while reading line")
+        line = line.rstrip("\n")
+        if line.startswith(ERROR_PREFIX):
+            error = line[len(ERROR_PREFIX):].strip()
+            raise CommandError(error)
+        if line == SUCCESS:
+            return None
+        return line
+
+    async def __read_full_output(self):
+        """Kind of like SyncMPDClient._read_lines, but without the iteration"""
+        result = []
+        while True:
+            line = await self.__read_output_line()
+            if line is None:
+                return result
+            else:
+                result.append(line)
+
+    # command provider interface
+
+    @classmethod
+    def add_command(cls, name, callback):
+        if hasattr(cls, name):
+            # twisted silently ignores them; probably, i'll make an
+            # experience that'll make me take the same router at some point.
+            raise AttributeError("Refusing to override the %s command"%name)
+        def f(self, *args):
+            result = asyncio.Future()
+            self.__commandqueue.put_nowait(
+                    (name, args, callback, result)
+                    )
+            return result
+        escaped_name = name.replace(" ", "_")
+        f.__name__ = escaped_name
+        setattr(cls, escaped_name, f)

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -170,14 +170,14 @@ class MPDClient(MPDClientBase):
                             loop=self.__loop,
                             )
                 except asyncio.TimeoutError:
-                    # the cancellation of the __commandqueue.get() that happens
+                    # The cancellation of the __commandqueue.get() that happens
                     # in this case is intended, and is just what asyncio.Queue
                     # suggests for "get with timeout".
 
                     subsystems = self._get_idle_interests()
                     if subsystems is None:
-                        # the presumably most quiet subsystem -- in this case,
-                        # idle is only used to keep the connection alive
+                        # The presumably most quiet subsystem -- in this case,
+                        # idle is only used to keep the connection alive.
                         subsystems = ["database"]
 
                     result = CommandResult("idle", subsystems, self._parse_list)
@@ -189,7 +189,7 @@ class MPDClient(MPDClientBase):
                 while True:
                     try:
                         if self.__command_enqueued is not None:
-                            # we're in idle mode
+                            # We're in idle mode.
                             line_future = asyncio.shield(self.__read_output_line())
                             await asyncio.wait([line_future, self.__command_enqueued],
                                     return_when=asyncio.FIRST_COMPLETED)
@@ -209,8 +209,8 @@ class MPDClient(MPDClientBase):
                 result = None
 
         except Exception as e:
-            # prevent the destruction of the pending task in the shutdown
-            # function -- it's just shutting down by itself
+            # Prevent the destruction of the pending task in the shutdown
+            # function -- it's just shutting down by itself.
             self.__run_task = None
             self.disconnect()
 
@@ -218,13 +218,13 @@ class MPDClient(MPDClientBase):
                 result._feed_error(e)
                 return
             else:
-                # typically this is a bug in mpd.asyncio
+                # Typically this is a bug in mpd.asyncio.
                 raise
 
     async def __distribute_idle_results(self):
-        # an exception flying out of here probably means a connection
-        # interruption during idle. this will just show like any other
-        # unhandled task exception and that's probably the best we can do
+        # An exception flying out of here probably means a connection
+        # interruption during idle. This will just show like any other
+        # unhandled task exception and that's probably the best we can do.
         while True:
             result = await self.__idle_results.get()
             idle_changes = list(await result)
@@ -251,10 +251,10 @@ class MPDClient(MPDClientBase):
 
     # copied and subtly modifiedstuff from base
 
-    # this is just a wrapper for the below
+    # This is just a wrapper for the below.
     def _write_line(self, text):
         self.__write(text + "\n")
-    # FIXME this code should be sharable
+    # FIXME This code should be shareable.
     _write_command = SyncMPDClient._write_command
 
 
@@ -297,7 +297,7 @@ class MPDClient(MPDClientBase):
 #            yield obj
 
     def _parse_objects_direct(self, lines, delimiters=[]):
-        # this is a workaround implementing the above comment on python 3.5. it
+        # This is a workaround implementing the above comment on Python 3.5. It
         # is recommended that the commented-out code be used for reasoning, and
         # that changes are applied there and only copied over to this
         # implementation.
@@ -346,7 +346,7 @@ class MPDClient(MPDClientBase):
     def add_command(cls, name, callback):
         command_class = CommandResultIterable if callback.mpd_commands_direct else CommandResult
         if hasattr(cls, name):
-            # idle and noidle are explicitly implemented, skipping them
+            # Idle and noidle are explicitly implemented, skipping them.
             return
         def f(self, *args):
             result = command_class(name, args, partial(callback, self))
@@ -375,10 +375,9 @@ class MPDClient(MPDClientBase):
 #            self.__idle_consumers.remove(entry)
 
     def idle(self, subsystems=()):
-        # this is a desugared workaround for python 3.5 like
-        # _parse_objects_direct. like there, please consider the above block
-        # authoritative and this a workaround, and only apply changes here once
-        # they're incorprated there.
+        # This is a desugared workaround for python 3.5.
+        # Please consider the above block authoritative and this a workaround,
+        # and only apply changes here once they're incorporated there.
 
         def final():
             self.__idle_consumers.remove(entry)

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -146,6 +146,12 @@ class MPDClient(MPDClientBase):
                 except CommandError as e:
                     result._feed_error(e)
                     break
+                except Exception as e:
+                    # see above
+                    result._feed_error(e)
+                    self.__run_task = None
+                    self.disconnect()
+                    return
                 result._feed_line(l)
                 if l is None:
                     break
@@ -178,7 +184,6 @@ class MPDClient(MPDClientBase):
         """Kind of like SyncMPDClient._read_line"""
         line = await self.__readline()
         if not line.endswith("\n"):
-            self.disconnect()
             raise ConnectionError("Connection lost while reading line")
         line = line.rstrip("\n")
         if line.startswith(ERROR_PREFIX):

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -5,9 +5,9 @@ from mpd.base import HELLO_PREFIX, ERROR_PREFIX, SUCCESS
 from mpd.base import MPDClientBase
 from mpd.base import MPDClient as SyncMPDClient
 from mpd.base import ProtocolError, ConnectionError, CommandError
-from mpd.base import mpd_command_provider
+from mpd.base import mpd_command_provider, mpd_commands
 
-class CommandResult(asyncio.Future):
+class BaseCommandResult(asyncio.Future):
     """A future that carries its command/args/callback with it for the
     convenience of passing it around to the command queue."""
 
@@ -15,18 +15,60 @@ class CommandResult(asyncio.Future):
         super().__init__()
         self._command = command
         self._args = args
-        self.__callback = callback
+        self._callback = callback
+
+class CommandResult(BaseCommandResult):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.__spooled_lines = []
 
     def _feed_line(self, line):
         """Put the given line into the callback machinery, and set the result on a None line."""
         if line is None:
-            self.set_result(self.__callback(self.__spooled_lines))
+            self.set_result(self._callback(self.__spooled_lines))
         else:
             self.__spooled_lines.append(line)
 
-    async def __aiter__(self):
-        raise NotImplementedError("async for x in clientcommand() is work in progress")
+    def _feed_error(self, error):
+        self.set_exception(error)
+
+class CommandResultIterable(BaseCommandResult):
+    """Variant of CommandResult where the underlying callback is an
+    asynchronous` generator, and can thus interpret lines as they come along.
+
+    The result can be used with the aiter interface (`async for`). If it is
+    still used as a future instead, it eventually results in a list.
+
+    Commands used with this CommandResult must use their passed lines not like
+    an iterable (as in the synchronous implementation), but as a asyncio.Queue.
+    Furthermore, they must check whether the queue elements are exceptions, and
+    raise them.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__spooled_lines = asyncio.Queue()
+
+    def _feed_line(self, line):
+        self.__spooled_lines.put_nowait(line)
+
+    _feed_error = _feed_line
+
+    def __await__(self):
+        asyncio.Task(self.__feed_future())
+        return super().__await__()
+
+    async def __feed_future(self):
+        result = []
+        async for r in self:
+            result.append(r)
+        self.set_result(result)
+
+    def __aiter__(self):
+        if self.done():
+            raise RuntimeError("Command result is already being consumed")
+        return self._callback(self.__spooled_lines).__aiter__()
+
 
 @mpd_command_provider
 class MPDClient(MPDClientBase):
@@ -56,15 +98,15 @@ class MPDClient(MPDClientBase):
         while True:
             result = await self.__commandqueue.get()
             self._write_command(result._command, result._args)
-            try:
-                responselines = await self.__read_full_output()
-                for l in responselines:
-                    result._feed_line(l)
-            except Exception as e:
-                # may be CommandError flying out of __read_fulloutput or any kind of exception from the callback
-                result.set_exception(e)
-            finally:
-                assert result.done(), "Result %s not done after __read_full_output was processed"%(result,)
+            while True:
+                try:
+                    l = await self.__read_output_line()
+                except CommandError as e:
+                    result._feed_error(e)
+                    break
+                result._feed_line(l)
+                if l is None:
+                    break
 
     # helper methods
 
@@ -81,7 +123,7 @@ class MPDClient(MPDClientBase):
         """Wrapper around .__wfile.write that handles encoding."""
         self.__wfile.write(text.encode('utf8'))
 
-    # copied stuff from base
+    # copied and subtly modifiedstuff from base
 
     async def __hello(self):
         # not catching the timeout error, it's actually pretty adaequate
@@ -121,25 +163,67 @@ class MPDClient(MPDClientBase):
             return None
         return line
 
-    async def __read_full_output(self):
-        """Kind of like SyncMPDClient._read_lines, but without the iteration"""
-        result = []
+    async def _parse_objects(self, lines, delimiters=[]):
+        """Like _parse_objects, but waits for lines"""
+        obj = {}
         while True:
-            line = await self.__read_output_line()
-            result.append(line)
+            line = await lines.get()
+            if isinstance(line, BaseException):
+                raise line
             if line is None:
-                return result
+                break
+            key, value = self._parse_pair(line, separator=": ")
+            key = key.lower()
+            if obj:
+                if key in delimiters:
+                    yield obj
+                    obj = {}
+                elif key in obj:
+                    if not isinstance(obj[key], list):
+                        obj[key] = [obj[key], value]
+                    else:
+                        obj[key].append(value)
+                    continue
+            obj[key] = value
+        if obj:
+            yield obj
+
+    # as the above works for everyone who calls `return _parse_objects` but
+    # *not* for those that return list(_parse_objects(...))[0], that single
+    # function is rewritten here to use the original _parse_objects
+
+    @mpd_commands('count', 'currentsong', 'readcomments', 'stats', 'status')
+    def _parse_object(self, lines):
+        objs = list(SyncMPDClient._parse_objects(self, lines))
+        if not objs:
+            return {}
+        return objs[0]
 
     # command provider interface
 
+    __wrap_async_iterator_parsers = [
+            # the very ones that return _parse_object directly
+            SyncMPDClient._parse_changes,
+            SyncMPDClient._parse_database,
+            SyncMPDClient._parse_messages,
+            SyncMPDClient._parse_mounts,
+            SyncMPDClient._parse_neighbors,
+            SyncMPDClient._parse_outputs,
+            SyncMPDClient._parse_playlists,
+            SyncMPDClient._parse_plugins,
+            SyncMPDClient._parse_songs,
+            ]
+
     @classmethod
     def add_command(cls, name, callback):
+        wrap_result = callback in cls.__wrap_async_iterator_parsers
+        command_class = CommandResultIterable if wrap_result else CommandResult
         if hasattr(cls, name):
             # twisted silently ignores them; probably, i'll make an
             # experience that'll make me take the same router at some point.
             raise AttributeError("Refusing to override the %s command"%name)
         def f(self, *args):
-            result = CommandResult(name, args, partial(callback, self))
+            result = command_class(name, args, partial(callback, self))
             self.__commandqueue.put_nowait(result)
             return result
         escaped_name = name.replace(" ", "_")

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -14,6 +14,9 @@ want to send commands after an idle returned (eg. current song notification
 pushers).
 
 Command lists are currently not supported.
+
+
+This module requires Python 3.5.2 or later to run.
 """
 
 import asyncio

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -117,9 +117,12 @@ class mpd_commands(object):
     callback.
     """
 
-    def __init__(self, *commands, is_direct=False):
+    def __init__(self, *commands, **kwargs):
         self.commands = commands
-        self.is_direct = is_direct
+        self.is_direct = kwargs.pop('is_direct', False)
+        if kwargs:
+            raise AttributeError("mpd_commands() got unexpected keyword"
+                    " arguments %s" % ",".join(kwargs))
 
     def __call__(self, ob):
         ob.mpd_commands = self.commands

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -542,8 +542,7 @@ class MPDClient(MPDClientBase):
         self._iterating = True
         return self._iterator_wrapper(iterator)
 
-    def _hello(self):
-        line = self._rfile.readline()
+    def _hello(self, line):
         if not line.endswith("\n"):
             self.disconnect()
             raise ConnectionError("Connection lost while reading MPD hello")
@@ -636,7 +635,8 @@ class MPDClient(MPDClientBase):
                 encoding="utf-8",
                 newline="\n")
         try:
-            self._hello()
+            helloline = self._rfile.readline()
+            self._hello(helloline)
         except:
             self.disconnect()
             raise

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -29,6 +29,12 @@ except ImportError:
                   "(twisted is not available for python >= 3.0 && python < 3.3)")
     TWISTED_MISSING = True
 
+if sys.version_info >= (3, 5):
+    # asyncio would be available in 3.4, but it's not supported by mpd.asyncio
+    import asyncio
+else:
+    asyncio = None
+
 try:
     import mock
 except ImportError:
@@ -905,6 +911,125 @@ class TestMPDProtocol(unittest.TestCase):
 
         self.protocol.close().addCallback(success)
 
+class AsyncMockServer:
+    def __init__(self):
+        self._output = asyncio.Queue()
+        self._expectations = []
+
+    def get_streams(self):
+        result = asyncio.Future()
+        result.set_result((self, self))
+        return result
+
+    def readline(self):
+        # directly passing around the awaitable
+        return self._output.get()
+
+    def write(self, data):
+        try:
+            next_write = self._expectations[0][0][0]
+        except IndexError:
+            self.error("Data written to mock even though none expected: %r" % data)
+        if next_write == data:
+            self._expectations[0][0].pop(0)
+            self._feed()
+        else:
+            self.error("Mock got %r, expected %r" % (data, next_write))
+
+    def error(self, message):
+        raise AssertionError(message)
+
+    def _feed(self):
+        if len(self._expectations[0][0]) == 0:
+            _, response_lines = self._expectations.pop(0)
+            for l in response_lines:
+                self._output.put_nowait(l)
+
+    def expect_exchange(self, request_lines, response_lines):
+        self._expectations.append((request_lines, response_lines))
+        self._feed()
+
+@unittest.skipIf(asyncio is None, "requires asyncio to be available")
+class TestAsyncioMPD(unittest.TestCase):
+    def init_client(self, odd_hello=None):
+        import mpd.asyncio
+
+        self.loop = asyncio.get_event_loop()
+
+        self.mockserver = AsyncMockServer()
+        asyncio.open_connection = mock.MagicMock(return_value=self.mockserver.get_streams())
+
+        if odd_hello is None:
+            hello_lines = [b'OK MPD mocker\n']
+        else:
+            hello_lines = odd_hello
+
+        self.mockserver.expect_exchange([], hello_lines)
+
+        self.client = mpd.asyncio.MPDClient()
+        self._await(self.client.connect(TEST_MPD_HOST, TEST_MPD_PORT, loop=self.loop))
+
+        asyncio.open_connection.assert_called_with(TEST_MPD_HOST, TEST_MPD_PORT, loop=self.loop)
+
+    def _await(self, future):
+        return self.loop.run_until_complete(future)
+
+    def test_oddhello(self):
+        self.assertRaises(mpd.base.ProtocolError, self.init_client, odd_hello=[b'NOT OK\n'])
+
+    @unittest.skip("This test would add 5 seconds of idling to the run")
+    def test_noresponse(self):
+        self.assertRaises(mpd.base.ConnectionError, self.init_client, odd_hello=[])
+
+    def test_status(self):
+        self.init_client()
+
+        self.mockserver.expect_exchange([b"status\n"], [
+            b"volume: 70\n",
+            b"repeat: 0\n",
+            b"random: 1\n",
+            b"single: 0\n",
+            b"consume: 0\n",
+            b"playlist: 416\n",
+            b"playlistlength: 7\n",
+            b"mixrampdb: 0.000000\n",
+            b"state: play\n",
+            b"song: 4\n",
+            b"songid: 19\n",
+            b"time: 28:403\n",
+            b"elapsed: 28.003\n",
+            b"bitrate: 465\n",
+            b"duration: 403.066\n",
+            b"audio: 44100:16:2\n",
+            b"OK\n",
+            ])
+
+        status = self._await(self.client.status())
+        self.assertEqual(status, {
+            'audio': '44100:16:2',
+            'bitrate': '465',
+            'consume': '0',
+            'duration': '403.066',
+            'elapsed': '28.003',
+            'mixrampdb': '0.000000',
+            'playlist': '416',
+            'playlistlength': '7',
+            'random': '1',
+            'repeat': '0',
+            'single': '0',
+            'song': '4',
+            'songid': '19',
+            'state': 'play',
+            'time': '28:403',
+            'volume': '70',
+            })
+
+    def test_mocker(self):
+        """Does the mock server refuse unexpected writes?"""
+        self.init_client()
+
+        self.mockserver.expect_exchange([b"expecting odd things\n"], [b""])
+        self.assertRaises(AssertionError, self._await, self.client.status())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a new approach to asyncio support. It is functional, but bare; before continuing by addressing the following, I'd like to have the groundwork reviewed:

* Idle is supported but noidle is not; while it could be added, I think that library-managed idling is more suitable for an asyncio port.
* Command lists are not supported yet.
* Python 3.6 is required. Support down to 3.4 should be possible, but requires extensive de-sugaring. Support for 3.5 would work with moderate de-sugaring. I'd recommend not going that route and declaring the asyncio interface 3.6+ – that's about the version where async became really well usable.

The top two commits are do modify the base implementation to make more of it usable with asyncio (hello: reduce code duplication by moving a line out of a private function; direct commands: explicit decoration and an extension point that make the asyncio version less fragile towards changes in base)

Please let me know whether the base changes are acceptable, or whether you'd rephrase them. (I'm not too happy with the "direct" wording, open for suggestions)

Closes: https://github.com/Mic92/python-mpd2/issues/30