### PR TITLE
Close transport on asyncio client disconnect

### DIFF
--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -134,6 +134,7 @@ class MPDClient(MPDClientBase):
             self.__run_task.cancel()
         if self.__idle_task is not None:
             self.__idle_task.cancel()
+        self.__wfile.close()
         self.__rfile = self.__wfile = None
         self.__run_task = self.__idle_task = None
         self.__commandqueue = self.__command_enqueued = None

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -948,6 +948,10 @@ class AsyncMockServer:
         else:
             self.error("Mock got %r, expected %r" % (data, next_write))
 
+    def close(self):
+        # todo: make sure calls to self.write fail after callling close
+        pass
+    
     def error(self, message):
         raise AssertionError(message)
 


### PR DESCRIPTION
The current disconnect method of  asyncio.MPDClient does not close the writing transport. A warning for this is issued when running the python3 interpreter with -Wdefault. As a result, the MPD server keeps alive the connection to the client unnecessarily. If this happens repeatedly, the dangling connections may cause the MPD server to reach its maximal connection limit.