### PR TITLE
Create TCP socket with `TCP_NODELAY`.

### DIFF
--- a/mpd/base.py
+++ b/mpd/base.py
@@ -592,6 +592,7 @@ class MPDClient(MPDClientBase):
             sock = None
             try:
                 sock = socket.socket(af, socktype, proto)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 sock.settimeout(self.timeout)
                 sock.connect(sa)


### PR DESCRIPTION
Nagle's algorithm plays badly with delayed ACK algorithm. MPD server doesn't set its socket option, so we need to fix the client side to make interactive clients more responsive.

To demonstrate the problem, consider this program which checks changed subsystems using `idle` and `noidle`:

    #!/usr/bin/env python3

    import mpd
    import time
    mpc = mpd.MPDClient()
    mpc.connect('localhost', 6600)
    t0 = time.time()
    for i in range(50):
        mpc.send_idle()
        mpc.noidle()
    t1 = time.time()
    print(t1 - t0)

This is the write-write-read patten that suffers from the ACK delay in each iteration. With `TCP_NODELAY`, it runs 500-1000x faster.
