### PR TITLE
add support for fetching album art

### DIFF
--- a/mpd/base.py
+++ b/mpd/base.py
@@ -359,6 +359,8 @@ class MPDClientBase(object):
     def _parse_stickers(self, lines):
         return dict(self._parse_raw_stickers(lines))
 
+    def albumart(self, uri):
+        return self._execute_binary("albumart", [uri])
 
 ###############################################################################
 # sync client
@@ -428,6 +430,7 @@ class MPDClient(MPDClientBase):
         self._iterating = False
         self._sock = None
         self._rfile = _NotConnected()
+        self._rbfile = _NotConnected()
         self._wfile = _NotConnected()
 
     def _send(self, command, args, retval):
@@ -549,6 +552,43 @@ class MPDClient(MPDClientBase):
             yield line
             line = self._read_line()
 
+    def _read_binary(self):
+        size = None
+        chunk_size = 0
+        while chunk_size == 0:
+            line = self._rbfile.readline().decode("utf-8")
+            if not line.endswith("\n"):
+                self.disconnect()
+                raise ConnectionError("Connection lost while reading line")
+            line = line.rstrip("\n")
+            if line.startswith(ERROR_PREFIX):
+                error = line[len(ERROR_PREFIX):].strip()
+                raise CommandError(error)
+            field, val = line.split(": ")
+            if field == "size":
+                size = int(val)
+            elif field == "binary":
+                chunk_size = int(val)
+        if size is None:
+            size = chunk_size
+        data = self._rbfile.read(chunk_size)
+        self._rbfile.read(1)  # discard newline
+        self._rbfile.readline().decode("utf-8")
+        return size, data
+
+    def _execute_binary(self, command, args):
+        data = bytearray()
+        assert len(args) == 1
+        args.append(0)
+        while True:
+            self._write_command(command, args)
+            size, chunk = self._read_binary()
+            data += chunk
+            args[-1] += len(chunk)
+            if len(data) == size:
+                break
+        return data
+
     def _read_command_list(self):
         try:
             for retval in self._command_list:
@@ -652,6 +692,7 @@ class MPDClient(MPDClientBase):
         if IS_PYTHON2:
             self._rfile = self._sock.makefile("r")
             self._wfile = self._sock.makefile("w")
+            self._rbfile = self._sock.makefile("rb")
         else:
             # - Force UTF-8 encoding, since this is dependant from the LC_CTYPE
             #   locale.
@@ -665,6 +706,8 @@ class MPDClient(MPDClientBase):
                 "w",
                 encoding="utf-8",
                 newline="\n")
+            self._rbfile = self._sock.makefile("rb")
+
         try:
             helloline = self._rfile.readline()
             self._hello(helloline)
@@ -677,6 +720,9 @@ class MPDClient(MPDClientBase):
         if (self._rfile is not None and
                 not isinstance(self._rfile, _NotConnected)):
             self._rfile.close()
+        if (self._rbfile is not None and
+                not isinstance(self._rbfile, _NotConnected)):
+            self._rbfile.close()
         if (self._wfile is not None and
                 not isinstance(self._wfile, _NotConnected)):
             self._wfile.close()


### PR DESCRIPTION
This adds support for MPD's `albumart` command [1], which uses a different response format than other commands [2].

I recognize that the implementation of this command doesn't follow the same pattern as other commands in this library. However, the need to iteratively issue the command and parse the response as binary made it difficult for me to see how it would fit. I'm open to suggestions for how to refactor this if this is an issue.

1. https://www.musicpd.org/doc/html/protocol.html?highlight=cover#the-music-database
2. https://www.musicpd.org/doc/html/protocol.html?highlight=cover#binary