### PR TITLE
Add a way to allow slow tests to be run

### DIFF
--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -94,6 +94,7 @@ class CommandResultIterable(BaseCommandResult):
 
 @mpd_command_provider
 class MPDClient(MPDClientBase):
+    __idle_task = None
     __run_task = None # doubles as indicator for being connected
 
     #: When in idle, this is a Future on which incoming commands should set a

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 import itertools
 import mpd
+import os
 import sys
 import types
 import warnings
@@ -1043,7 +1044,8 @@ class TestAsyncioMPD(unittest.TestCase):
     def test_oddhello(self):
         self.assertRaises(mpd.base.ProtocolError, self.init_client, odd_hello=[b'NOT OK\n'])
 
-    @unittest.skip("This test would add 5 seconds of idling to the run")
+    @unittest.skipIf(os.getenv('RUN_SLOW_TESTS') is None,
+                     "This test would add 5 seconds of idling to the run (export RUN_SLOW_TESTS=1 to run anyway)")
     def test_noresponse(self):
         self.assertRaises(mpd.base.ConnectionError, self.init_client, odd_hello=[])
 


### PR DESCRIPTION
* asyncio: Initialize __idle_task
    
    Otherwise, the tests fail if test_noresponse() is not skipped:
    disconnect() checks whether __idle_task is None, and gets an
    AttributeError if connect() never succeeded.

* tests: Add a way to allow slow tests to be run
    
    On continuous integration systems that are not being used interactively,
    it will probably take more than 5 seconds to install the
    build-dependencies anyway, and usually nobody will be waiting for the
    results, so we might as well run all tests - even the slow ones.