### PR TITLE
Fix: Error with delimiters in asyncio

### DIFF
--- a/mpd/base.py
+++ b/mpd/base.py
@@ -288,7 +288,6 @@ class MPDClientBase(object):
 
     @mpd_commands('list', is_direct=True)
     def _parse_list_groups(self, lines):
-        lines = iter(lines)
         return self._parse_objects_direct(lines, lookup_delimiter=True)
 
     @mpd_commands('readmessages', is_direct=True)


### PR DESCRIPTION
There is an error in asyncio._parse_objects_direct when executing
commands as 'search':

UnboundLocalError: local variable 'delimiters' referenced before assignment

This error occurs because WrappedLoop does not have access to the param 'delimiters', so we have to pass it again when the instance of that class is created.