### PR TITLE
Add support for fetching album art (with unit tests)

### DIFF
--- a/doc/topics/commands.rst
+++ b/doc/topics/commands.rst
@@ -598,7 +598,15 @@ Stored playlists
 The music database
 ------------------
 
+.. function:: MPDClient.albumart(uri)
 
+
+    Returns the album art image for the given song.
+
+    *URI* is always a single file or URL.
+
+    The returned value is the binary contents of the album art image. If the given URI is invalid,
+    or the song does not have an album cover art file that MPD recognizes, a CommandError is thrown.
 .. function:: MPDClient.count(tag, needle[, ..., "group", grouptype])
 
 

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -551,15 +551,15 @@ class MPDClient(MPDClientBase):
             yield line
             line = self._read_line()
 
-    def _read_numbytes(self, numToRead):
-        retVal = bytearray()
-        while numToRead > 0:
-            readResult = self._rbfile.read(numToRead)
-            if len(readResult) == 0:
+    def _read_chunk(self, amount):
+        chunk = bytearray()
+        while amount > 0:
+            result = self._rbfile.read(amount)
+            if len(result) == 0:
                 break
-            retVal.extend(readResult)
-            numToRead -= len(readResult)
-        return bytes(retVal)
+            chunk.extend(result)
+            amount -= len(result)
+        return bytes(chunk)
 
     def _read_binary(self):
         size = None
@@ -582,7 +582,7 @@ class MPDClient(MPDClientBase):
         if size is None:
             size = chunk_size
         
-        data = self._read_numbytes(chunk_size)
+        data = self._read_chunk(chunk_size)
 
         if len(data) != chunk_size:
             self.disconnect()

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -525,7 +525,7 @@ class MPDClient(MPDClientBase):
 
     def _read_line(self):
         line = self._rbfile.readline()
-        if not IS_PYTHON2:
+        if self.use_unicode or not IS_PYTHON2:
             line = line.decode("utf-8")
         if self.use_unicode:
             line = decode_str(line)

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -553,8 +553,8 @@ class MPDClient(MPDClientBase):
 
     def _read_binary(self):
         size = None
-        chunk_size = 0
-        while chunk_size == 0:
+        chunk_size = None
+        while chunk_size is None:
             line = self._rbfile.readline().decode("utf-8")
             if not line.endswith("\n"):
                 self.disconnect()
@@ -571,8 +571,8 @@ class MPDClient(MPDClientBase):
         if size is None:
             size = chunk_size
         data = self._rbfile.read(chunk_size)
-        self._rbfile.read(1)  # discard newline
-        self._rbfile.readline().decode("utf-8")
+        self._rbfile.read(1)  # discard newline after binary content
+        self._rbfile.readline().decode("utf-8") # trailing "OK\n"
         return size, data
 
     def _execute_binary(self, command, args):

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -358,6 +358,8 @@ class MPDClientBase(object):
     def _parse_stickers(self, lines):
         return dict(self._parse_raw_stickers(lines))
 
+    def albumart(self, uri):
+        return self._execute_binary("albumart", [uri])
 
 ###############################################################################
 # sync client
@@ -427,6 +429,7 @@ class MPDClient(MPDClientBase):
         self._iterating = False
         self._sock = None
         self._rfile = _NotConnected()
+        self._rbfile = _NotConnected()
         self._wfile = _NotConnected()
 
     def _send(self, command, args, retval):
@@ -548,6 +551,43 @@ class MPDClient(MPDClientBase):
             yield line
             line = self._read_line()
 
+    def _read_binary(self):
+        size = None
+        chunk_size = 0
+        while chunk_size == 0:
+            line = self._rbfile.readline().decode("utf-8")
+            if not line.endswith("\n"):
+                self.disconnect()
+                raise ConnectionError("Connection lost while reading line")
+            line = line.rstrip("\n")
+            if line.startswith(ERROR_PREFIX):
+                error = line[len(ERROR_PREFIX):].strip()
+                raise CommandError(error)
+            field, val = line.split(": ")
+            if field == "size":
+                size = int(val)
+            elif field == "binary":
+                chunk_size = int(val)
+        if size is None:
+            size = chunk_size
+        data = self._rbfile.read(chunk_size)
+        self._rbfile.read(1)  # discard newline
+        self._rbfile.readline().decode("utf-8")
+        return size, data
+
+    def _execute_binary(self, command, args):
+        data = bytearray()
+        assert len(args) == 1
+        args.append(0)
+        while True:
+            self._write_command(command, args)
+            size, chunk = self._read_binary()
+            data += chunk
+            args[-1] += len(chunk)
+            if len(data) == size:
+                break
+        return data
+
     def _read_command_list(self):
         try:
             for retval in self._command_list:
@@ -651,6 +691,7 @@ class MPDClient(MPDClientBase):
         if IS_PYTHON2:
             self._rfile = self._sock.makefile("r")
             self._wfile = self._sock.makefile("w")
+            self._rbfile = self._sock.makefile("rb")
         else:
             # - Force UTF-8 encoding, since this is dependant from the LC_CTYPE
             #   locale.
@@ -664,6 +705,8 @@ class MPDClient(MPDClientBase):
                 "w",
                 encoding="utf-8",
                 newline="\n")
+            self._rbfile = self._sock.makefile("rb")
+
         try:
             helloline = self._rfile.readline()
             self._hello(helloline)
@@ -676,6 +719,9 @@ class MPDClient(MPDClientBase):
         if (self._rfile is not None and
                 not isinstance(self._rfile, _NotConnected)):
             self._rfile.close()
+        if (self._rbfile is not None and
+                not isinstance(self._rbfile, _NotConnected)):
+            self._rbfile.close()
         if (self._wfile is not None and
                 not isinstance(self._wfile, _NotConnected)):
             self._wfile.close()

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -685,14 +685,13 @@ class TestMPDClient(unittest.TestCase):
 
 # MPD client tests which do not mock the socket, but rather replace it
 # with a real socket from a socket
+@unittest.skipIf(not hasattr(socket, "socketpair"),
+                     "Socketpair is not supported on this platform")
 class TestMPDClientSocket(unittest.TestCase):
 
     longMessage = True
 
     def setUp(self):
-        if not hasattr(socket, "socketpair"):
-            self.skipTest("Socketpair is not supported on this platform")
-
         self.connect_patch = mock.patch("mpd.MPDClient._connect_unix")
         self.connect_mock = self.connect_patch.start()
 

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -260,12 +260,12 @@ class TestMPDClient(unittest.TestCase):
         self.MPDWillReturnBinary(b"size: 17\n", b"binary: 3\n",
             b"\x00\x00\x00", b"\n", b"OK\n")
         
-        realWriteFunc = self.client._wfile.write
+        real_write_func = self.client._wfile.write
 
         self.assertRaises(mpd.ConnectionError,
             lambda: self.client.albumart('a/full/path.mp3'))
         
-        realWriteFunc.assert_has_calls([mock.call('albumart "a/full/path.mp3" "0"\n'),
+        real_write_func.assert_has_calls([mock.call('albumart "a/full/path.mp3" "0"\n'),
             mock.call('albumart "a/full/path.mp3" "3"\n')])
         
         self.assertIs(self.client._sock, None)
@@ -274,40 +274,40 @@ class TestMPDClient(unittest.TestCase):
         self.MPDWillReturnBinary(b"size: 8\n", b"binary: 8\n",
             b"\x00\x01\x02\x03")
         
-        realWriteFunc = self.client._wfile.write
+        real_write_func = self.client._wfile.write
 
         self.assertRaises(mpd.ConnectionError,
             lambda: self.client.albumart('a/full/path.mp3'))
         
-        realWriteFunc.assert_called_with('albumart "a/full/path.mp3" "0"\n')
+        real_write_func.assert_called_with('albumart "a/full/path.mp3" "0"\n')
         
         self.assertIs(self.client._sock, None)
 
     def test_binary_albumart_singlechunk_networkinterrupted(self):
         # length 16
-        expectedBinary = b'\xA0\xA1\xA2\xA3\xA4\xA5\xA6\xA7\xA8\xA9\xAA\xAB\xAC\xAD\xAE\xAF'
+        expected_binary = b'\xA0\xA1\xA2\xA3\xA4\xA5\xA6\xA7\xA8\xA9\xAA\xAB\xAC\xAD\xAE\xAF'
         
         self.MPDWillReturnBinary(b"binary: 16\n",
-            expectedBinary[0:9],
-            expectedBinary[9:14],
-            expectedBinary[14:16], b"\n", b"OK\n")
+            expected_binary[0:9],
+            expected_binary[9:14],
+            expected_binary[14:16], b"\n", b"OK\n")
         
-        realBinary = self.client.albumart('a/full/path.mp3')
+        real_binary = self.client.albumart('a/full/path.mp3')
         self.assertMPDReceived('albumart "a/full/path.mp3" "0"\n')
-        self.assertEqual(realBinary, expectedBinary)
+        self.assertEqual(real_binary, expected_binary)
         self.client._rbfile.readline.assert_has_calls([mock.call(), mock.call()])
         self.client._rbfile.read.assert_has_calls([mock.call(16), mock.call(7), mock.call(2), mock.call(1)])
 
     def test_binary_albumart_singlechunk_nosize(self):
         # length: 16
-        expectedBinary = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01'
+        expected_binary = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01'
         
         self.MPDWillReturnBinary(b"binary: 16\n",
-            expectedBinary, b"\n", b"OK\n")
+            expected_binary, b"\n", b"OK\n")
         
-        realBinary = self.client.albumart('a/full/path.mp3')
+        real_binary = self.client.albumart('a/full/path.mp3')
         self.assertMPDReceived('albumart "a/full/path.mp3" "0"\n')
-        self.assertEqual(realBinary, expectedBinary)
+        self.assertEqual(real_binary, expected_binary)
         # readline at beginning for command, readline at end for OK
         self.client._rbfile.readline.assert_has_calls([mock.call(), mock.call()])
         # chunk of specified size for data, size one for terminating newline
@@ -315,14 +315,14 @@ class TestMPDClient(unittest.TestCase):
 
     def test_binary_albumart_singlechunk_sizeheader(self):
         # length: 16
-        expectedBinary = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01'
+        expected_binary = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01'
         
         self.MPDWillReturnBinary(b"size: 16\n", b"binary: 16\n",
-            expectedBinary, b"\n", b"OK\n")
+            expected_binary, b"\n", b"OK\n")
         
-        realBinary = self.client.albumart('a/full/path.mp3')
+        real_binary = self.client.albumart('a/full/path.mp3')
         self.assertMPDReceived('albumart "a/full/path.mp3" "0"\n')
-        self.assertEqual(realBinary, expectedBinary)
+        self.assertEqual(real_binary, expected_binary)
         # readline at beginning for command, readline at end for OK
         self.client._rbfile.readline.assert_has_calls([mock.call(), mock.call()])
         # chunk of specified size for data, size one for terminating newline
@@ -330,22 +330,22 @@ class TestMPDClient(unittest.TestCase):
 
     def test_binary_albumart_even_multichunk(self):
         # length: 16 each
-        expectedChunk1 = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01'
-        expectedChunk2 = b'\x0A\x0B\x0C\x0D\x0E\x0F\x10\x1F\x2F\x2D\x33\x0D\x00\x00\x11\x13'
-        expectedChunk3 = b'\x99\x88\x77\xDD\xD0\xF0\x20\x70\x71\x17\x13\x31\xFF\xFF\xDD\xFF'
-        expectedBinary = expectedChunk1 + expectedChunk2 + expectedChunk3
+        expected_chunk1 = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01'
+        expected_chunk2 = b'\x0A\x0B\x0C\x0D\x0E\x0F\x10\x1F\x2F\x2D\x33\x0D\x00\x00\x11\x13'
+        expected_chunk3 = b'\x99\x88\x77\xDD\xD0\xF0\x20\x70\x71\x17\x13\x31\xFF\xFF\xDD\xFF'
+        expected_binary = expected_chunk1 + expected_chunk2 + expected_chunk3
 
         # 3 distinct commands expected
         self.MPDWillReturnBinary(b"size: 48\n", b"binary: 16\n",
-            expectedChunk1, b"\n", b"OK\n", b"size: 48\n", b"binary: 16\n",
-            expectedChunk2, b"\n", b"OK\n", b"size: 48\n", b"binary: 16\n",
-            expectedChunk3, b"\n", b"OK\n")
+            expected_chunk1, b"\n", b"OK\n", b"size: 48\n", b"binary: 16\n",
+            expected_chunk2, b"\n", b"OK\n", b"size: 48\n", b"binary: 16\n",
+            expected_chunk3, b"\n", b"OK\n")
         
-        realBinary = self.client.albumart('a/full/path.mp3')
+        real_binary = self.client.albumart('a/full/path.mp3')
         self.client._wfile.write.assert_has_calls([mock.call('albumart "a/full/path.mp3" "0"\n'),
                                                 mock.call('albumart "a/full/path.mp3" "16"\n'),
                                                 mock.call('albumart "a/full/path.mp3" "32"\n')])
-        self.assertEqual(realBinary, expectedBinary)
+        self.assertEqual(real_binary, expected_binary)
 
         self.client._rbfile.readline.assert_has_calls([mock.call(),
             mock.call(), mock.call(), mock.call(), mock.call(), mock.call()])
@@ -355,21 +355,21 @@ class TestMPDClient(unittest.TestCase):
     def test_binary_albumart_odd_multichunk(self):
         # lengths: 17, 15, 1
         expectedChunk1 = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01\x13'
-        expectedChunk2 = b'\x0A\x0B\x0C\x0D\x0E\x0F\x10\x1F\x2F\x2D\x33\x0D\x00\x00\x11'
-        expectedChunk3 = b'\x99'
-        expectedBinary = expectedChunk1 + expectedChunk2 + expectedChunk3
+        expected_chunk2 = b'\x0A\x0B\x0C\x0D\x0E\x0F\x10\x1F\x2F\x2D\x33\x0D\x00\x00\x11'
+        expected_chunk3 = b'\x99'
+        expected_binary = expected_chunk1 + expected_chunk2 + expected_chunk3
 
         # 3 distinct commands expected
         self.MPDWillReturnBinary(b"size: 33\n", b"binary: 17\n",
-            expectedChunk1, b"\n", b"OK\n", b"size: 33\n", b"binary: 15\n",
-            expectedChunk2, b"\n", b"OK\n", b"size: 33\n", b"binary: 1\n",
-            expectedChunk3, b"\n", b"OK\n")
+            expected_chunk1, b"\n", b"OK\n", b"size: 33\n", b"binary: 15\n",
+            expected_chunk2, b"\n", b"OK\n", b"size: 33\n", b"binary: 1\n",
+            expected_chunk3, b"\n", b"OK\n")
         
-        realBinary = self.client.albumart('a/full/path.mp3')
+        real_binary = self.client.albumart('a/full/path.mp3')
         self.client._wfile.write.assert_has_calls([mock.call('albumart "a/full/path.mp3" "0"\n'),
                                                 mock.call('albumart "a/full/path.mp3" "17"\n'),
                                                 mock.call('albumart "a/full/path.mp3" "32"\n')])
-        self.assertEqual(realBinary, expectedBinary)
+        self.assertEqual(real_binary, expected_binary)
 
         self.client._rbfile.readline.assert_has_calls([mock.call(),
             mock.call(), mock.call(), mock.call(), mock.call(), mock.call()])
@@ -381,9 +381,9 @@ class TestMPDClient(unittest.TestCase):
         self.MPDWillReturnBinary(b"size: 0\n", b"binary: 0\n",
             b"\n", b"OK\n")
         
-        realBinary = self.client.albumart('a/full/path.mp3')
+        real_binary = self.client.albumart('a/full/path.mp3')
         self.assertMPDReceived('albumart "a/full/path.mp3" "0"\n')
-        self.assertEqual(realBinary, b"")
+        self.assertEqual(real_binary, b"")
 
         self.client._rbfile.readline.assert_has_calls([mock.call(), mock.call()])
         self.client._rbfile.read.assert_has_calls([mock.call(1)])

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -354,7 +354,7 @@ class TestMPDClient(unittest.TestCase):
                 
     def test_binary_albumart_odd_multichunk(self):
         # lengths: 17, 15, 1
-        expectedChunk1 = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01\x13'
+        expected_chunk1 = b'\x01\x02\x00\x03\x04\x00\xFF\x05\x07\x08\x0A\x0F\xF0\xA5\x00\x01\x13'
         expected_chunk2 = b'\x0A\x0B\x0C\x0D\x0E\x0F\x10\x1F\x2F\x2D\x33\x0D\x00\x00\x11'
         expected_chunk3 = b'\x99'
         expected_binary = expected_chunk1 + expected_chunk2 + expected_chunk3

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -690,6 +690,9 @@ class TestMPDClientSocket(unittest.TestCase):
     longMessage = True
 
     def setUp(self):
+        if not hasattr(socket, "socketpair"):
+            self.skipTest("Socketpair is not supported on this platform")
+
         self.connect_patch = mock.patch("mpd.MPDClient._connect_unix")
         self.connect_mock = self.connect_patch.start()
 


### PR DESCRIPTION
This PR builds upon the work done by @auchter in #111, and implements support for the `albumart` MPD command. The core work was all his; I added unit tests, documentation, and some edge case tweaks. (If needed, I'm happy to squash commits, merge these changes into the original #111 branch, or otherwise.)

Protocol documentation references as per #111:

1. https://www.musicpd.org/doc/html/protocol.html?highlight=cover#the-music-database
2. https://www.musicpd.org/doc/html/protocol.html?highlight=cover#binary