### PR TITLE
asyncio: Update tests to cover more

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ for more information)
 
 The following features were added:
 
--  Python 3 support (but you need at least Python 2.7 or 3.4)
+-  Python 3 support (but you need at least Python 3.6)
 -  asyncio/twisted support
 -  support for the client-to-client protocol
 -  support for new commands from MPD (seekcur, prio, prioid,

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -1290,6 +1290,28 @@ class TestAsyncioMPD(unittest.TestCase):
         self.init_client()
         self._await(self._test_outputs())
 
+    async def _test_list(self):
+        self.mockserver.expect_exchange([b'list "album"\n'], [
+            b"Album: first\n",
+            b"Album: second\n",
+            b"OK\n",
+            ])
+
+        list_ = self.client.list("album")
+
+        expected = iter([
+                {'album': 'first'},
+                {'album': 'second'},
+                ])
+
+        async for o in list_:
+            self.assertEqual(o, next(expected))
+        self.assertRaises(StopIteration, next, expected)
+
+    def test_list(self):
+        self.init_client()
+        self._await(self._test_list())
+
     def test_mocker(self):
         """Does the mock server refuse unexpected writes?"""
         self.init_client()

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -31,8 +31,7 @@ except ImportError:
                   "(twisted is not available for python >= 3.0 && python < 3.3)")
     TWISTED_MISSING = True
 
-if sys.version_info >= (3, 5):
-    # asyncio would be available in 3.4, but it's not supported by mpd.asyncio
+if sys.version_info >= (3,):
     import asyncio
 else:
     asyncio = None

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -1261,6 +1261,35 @@ class TestAsyncioMPD(unittest.TestCase):
             'volume': '70',
             })
 
+    async def _test_outputs(self):
+        self.mockserver.expect_exchange([b"outputs\n"], [
+            b"outputid: 0\n",
+            b"outputname: My ALSA Device\n",
+            b"plugin: alsa\n",
+            b"outputenabled: 0\n",
+            b"attribute: dop=0\n",
+            b"outputid: 1\n",
+            b"outputname: My FM transmitter\n",
+            b"plugin: fmradio\n",
+            b"outputenabled: 1\n",
+            b"OK\n",
+            ])
+
+        outputs = self.client.outputs()
+
+        expected = iter([
+                {'outputid': '0', 'outputname': 'My ALSA Device', 'plugin': 'alsa', 'outputenabled': '0', 'attribute': 'dop=0'},
+                {'outputid': '1', 'outputname': 'My FM transmitter', 'plugin': 'fmradio', 'outputenabled': '1'},
+                ])
+
+        async for o in outputs:
+            self.assertEqual(o, next(expected))
+        self.assertRaises(StopIteration, next, expected)
+
+    def test_outputs(self):
+        self.init_client()
+        self._await(self._test_outputs())
+
     def test_mocker(self):
         """Does the mock server refuse unexpected writes?"""
         self.init_client()

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ def read(fname):
 setup(
     name="python-mpd2",
     version=VERSION,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     description="A Python MPD client library",
     long_description=read('README.rst'),
     classifiers=CLASSIFIERS,

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def read(fname):
 setup(
     name="python-mpd2",
     version=VERSION,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
+    python_requires='>=3.6',
     description="A Python MPD client library",
     long_description=read('README.rst'),
     classifiers=CLASSIFIERS,

--- a/shell.nix
+++ b/shell.nix
@@ -4,12 +4,11 @@ stdenv.mkDerivation {
   name = "env";
   buildInputs = [
     bashInteractive
-    python27
     python36
     python37
     python38
     python39
-    pypy
+    pypy3
     (python38.withPackages(ps: [ps.setuptools ps.tox ps.wheel ps.twine]))
   ];
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,pypy
+envlist = py36,py37,py38,py39,pypy3
 
 [testenv]
 deps = mock

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,3 @@ commands = coverage erase
            coverage run -m unittest mpd.tests
            coverage report
            coverage html -d coverage_html/{envname}
-
-[testenv:py26]
-deps = mock
-       unittest2
-       coverage
-       Twisted
-commands = coverage erase
-           coverage run -m unittest mpd.tests
-           coverage report
-           coverage html -d coverage_html/{envname}


### PR DESCRIPTION
These changes remove a minor line of cruft that's obsolete after #134 (which this practically depends on), and add to the tests to cover the code that was questionable for possibly reintroducing the #117 bug.

Test coverage goes up from 58% to 69% for that file in the py39 tests I ran.