### PR TITLE
Add readpicture command

### DIFF
--- a/doc/topics/commands.rst
+++ b/doc/topics/commands.rst
@@ -743,6 +743,20 @@ The music database
     Vorbis comments.
 
 
+.. function:: MPDClient.readpicture(uri)
+
+
+    Returns the embedded cover image for the given song.
+
+    *URI* is always a single file or URL.
+
+    The returned value is a dictionary containing the embedded cover image in its
+    ``'binary'`` entry, and potentially the picture's MIME type in its ``'type'`` entry.
+    If the given URI is invalid, a CommandError is thrown. If the given song URI exists,
+    but the song does not have an embedded cover image that MPD recognizes, an empty
+    dictionary is returned.
+
+
 .. function:: MPDClient.search(type, what[, ..., startend])
 
 

--- a/examples/coverart.py
+++ b/examples/coverart.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# IMPORTS
+from mpd import (MPDClient, CommandError)
+from socket import error as SocketError
+from sys import exit
+from PIL import Image
+from io import BytesIO
+
+## SETTINGS
+##
+HOST = 'localhost'
+PORT = '6600'
+PASSWORD = False
+SONG = ''
+###
+
+client = MPDClient()
+
+try:
+    client.connect(host=HOST, port=PORT)
+except SocketError:
+    exit(1)
+
+if PASSWORD:
+    try:
+        client.password(PASSWORD)
+    except CommandError:
+        exit(1)
+
+try:
+    cover_art = client.readpicture(SONG)
+except CommandError:
+    exit(1)
+
+if 'binary' not in cover_art:
+    # The song exists but has no embedded cover art
+    print("No embedded art found!")
+    exit(1)
+
+if 'type' in cover_art:
+    print("Cover art of type " + cover_art['type'])
+
+with Image.open(BytesIO(cover_art['binary'])) as img:
+    img.show()
+
+client.disconnect()
+
+# VIM MODLINE
+# vim: ai ts=4 sw=4 sts=4 expandtab

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -362,16 +362,16 @@ class MPDClient(MPDClientBase):
             chunk = metadata.pop('binary', None)
 
             if final_metadata is None:
+                data = chunk
                 final_metadata = metadata
+                if not data:
+                    break
                 try:
                     size = int(final_metadata['size'])
                 except KeyError:
                     size = len(chunk)
                 except ValueError:
                     raise CommandError("Size data unsuitable for binary transfer")
-                data = chunk
-                if not data:
-                    break
             else:
                 if metadata != final_metadata:
                     raise CommandError("Metadata of binary data changed during transfer")

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -423,7 +423,7 @@ class MPDClientBase(object):
     def _parse_stickers(self, lines):
         return dict(self._parse_raw_stickers(lines))
 
-    @mpd_commands("albumart", is_binary=True)
+    @mpd_commands("albumart", "readpicture", is_binary=True)
     def _parse_plain_binary(self, structure):
         return structure
 
@@ -647,16 +647,16 @@ class MPDClient(MPDClientBase):
             chunk = metadata.pop('binary', None)
 
             if final_metadata is None:
+                data = chunk
                 final_metadata = metadata
+                if not data:
+                    break
                 try:
                     size = int(final_metadata['size'])
                 except KeyError:
                     size = len(chunk)
                 except ValueError:
                     raise CommandError("Size data unsuitable for binary transfer")
-                data = chunk
-                if not data:
-                    break
             else:
                 if metadata != final_metadata:
                     raise CommandError("Metadata of binary data changed during transfer")

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -1450,6 +1450,10 @@ class TestAsyncioMPD(unittest.TestCase):
         self.init_client()
         self._await(self._test_readpicture())
 
+    def test_readpicture_empty(self):
+        self.init_client()
+        self._await(self._test_readpicture_empty())
+
     def test_mocker(self):
         """Does the mock server refuse unexpected writes?"""
         self.init_client()


### PR DESCRIPTION
Based on the excellent work done in #141. Fixes #121.

This PR makes the required tweaks to account for empty responses from binary commands, as well as adding documentation and tests for `readpicture`. An example script is also provided for practical testing.