### PR TITLE
Update reference to porting guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,9 @@ Difference with python-mpd
 
 python-mpd2 is a fork of `python-mpd`_.  While 0.4.x was backwards compatible
 with python-mpd, starting with 0.5 provides enhanced features which are *NOT*
-backward compatibles with the original `python-mpd`_ package.  (see PORTING.txt
-for more information)
+backward compatibles with the original `python-mpd`_ package (see `Porting
+Guide <https://python-mpd2.readthedocs.io/en/latest/topics/porting.html>`__
+for more information).
 
 The following features were added:
 


### PR DESCRIPTION
002ab565f93e59c99043121f081a1cb30b7c70bb renamed this file from
PORTING.txt to PORTING.rst, while
d87113bc6559a02fa55da3cca5179defde236d7e moved PORTING.rst into the docs
tree.

Link to the rendered file instead for consistency.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>