### PR TITLE
asyncio: Initialize rfile/wfile in MPDClient constructor

### DIFF
--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -160,6 +160,10 @@ class MPDClient(MPDClientBase):
     # freespinning tasks create warnings.
     COMMAND_QUEUE_LENGTH = 128
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__rfile = self.__wfile = None
+
     async def connect(self, host, port=6600, loop=None):
         if "/" in host:
             r, w = await asyncio.open_unix_connection(host, loop=loop)


### PR DESCRIPTION
Previously a call to `disconnect()` before successfully having
connected at least once would fail with an AttributeError because
MPDClient.__wfile would not have been initialized.

Fixes: #152

**Disclaimer**
This is an educated guess and has not been verified to do anything meaningful. Though I believe it won't set your house on fire or make the situation worse than it was.