### PR TITLE
async: Tolerate early disconnects

### DIFF
--- a/examples/asyncio_example.py
+++ b/examples/asyncio_example.py
@@ -5,6 +5,10 @@ from mpd.asyncio import MPDClient
 async def main():
     print("Create MPD client")
     client = MPDClient()
+
+    # Not necessary, but should not cause any trouble either
+    client.disconnect()
+
     try:
         await client.connect('localhost', 6600)
     except Exception as e:


### PR DESCRIPTION
The typing was added anticipating [145], and can be removed if that's
not going anywhere; more important was documenting the variable (even
though it's internal), and making sure it's only accessed in ways that
tolerate double disconnects (eg. due to a network disconnect racing
against a user disconnect, or because something disconnects just to be
sure).

Closes: https://github.com/Mic92/python-mpd2/issues/157

[145]: https://github.com/Mic92/python-mpd2/pull/145/files