### PR TITLE
Parse failure responses in CommandError exception

### DIFF
--- a/examples/coverart.py
+++ b/examples/coverart.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # IMPORTS
-from mpd import (MPDClient, CommandError)
+from mpd import (MPDClient, CommandError, FailureResponseCode)
 from socket import error as SocketError
 from sys import exit
 from PIL import Image
@@ -28,6 +28,15 @@ if PASSWORD:
         client.password(PASSWORD)
     except CommandError:
         exit(1)
+
+try:
+    missing_cover_art = client.albumart("does/not/exist")
+except CommandError as error:
+    # Asking for media that does not exist or media that has no
+    # albumart should raise:
+    #   mpd.base.CommandError: [50@0] {albumart} No file exists
+    if error.errno is not FailureResponseCode.NO_EXIST:
+        raise error
 
 try:
     cover_art = client.readpicture(SONG)

--- a/examples/errorhandling.py
+++ b/examples/errorhandling.py
@@ -44,9 +44,11 @@ class MPDPoller(object):
 
             # Catch errors with the password command (e.g., wrong password)
             except CommandError as e:
+                # On CommandErrors we have access to the parsed error response
+                # split into errno, offset, command and msg.
                 raise PollerError("Could not connect to '%s': "
-                                  "password commmand failed: %s" %
-                                  (self._host, e))
+                                  "password commmand failed: [%d] %s" %
+                                  (self._host, e.errno, e.msg))
 
             # Catch all other possible errors
             except (MPDError, IOError) as e:

--- a/mpd/__init__.py
+++ b/mpd/__init__.py
@@ -20,12 +20,14 @@
 from mpd.base import CommandError
 from mpd.base import CommandListError
 from mpd.base import ConnectionError
+from mpd.base import FailureResponseCode
 from mpd.base import IteratingError
 from mpd.base import MPDClient
 from mpd.base import MPDError
 from mpd.base import PendingCommandError
 from mpd.base import ProtocolError
 from mpd.base import VERSION
+
 
 try:
     from mpd.twisted import MPDProtocol


### PR DESCRIPTION
This allows for improved error handling based on error numbers, offsets
in a command list, command and ultimately also hands you the literal
error message.

The whole story is, that a home-assistant user came forward complainig
about the noise from `albumart` commands that returned 

> [50@0] {albumart} No file exists

for every song, that didn't have any. There is currently no clean way to
ignore specific errors, but to rely on string matching. Instead of everyone
doing that for themselves I believe a simple pattern like this might be
useful.