### PR TITLE
Asyncio handle idle errors

### DIFF
--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -1272,6 +1272,13 @@ class TestAsyncioMPD(unittest.TestCase):
             TEST_MPD_HOST, TEST_MPD_PORT, loop=self.loop
         )
 
+    def __del__(self):
+        # Clean up after init_client. (This works for now; if it causes
+        # trouble, change all init_client to a `with init_client` or use
+        # fixtures).
+        if hasattr(self, "client"):
+            self.client.disconnect()
+
     def _await(self, future):
         return self.loop.run_until_complete(future)
 


### PR DESCRIPTION
Closes https://github.com/Mic92/python-mpd2/issues/165 by turning any error during idle into idle events (after all, something *did* possibly change around, for example, the database, but the application may not be able to read the status now).

Along with tests to go with it, and some test cleanup as the idle test runs long enough that mockers start being GC'd while their clients are still around enough to send idle commands. (They always did, but the tests ran though fast enough to not cause the warnings that'd now show).