### PR TITLE
tests: Use built-in unittest.mock instead of external mock

### DIFF
--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -12,6 +12,7 @@ import types
 import warnings
 
 import unittest
+from unittest import mock
 
 try:
     from twisted.python.failure import Failure
@@ -26,11 +27,6 @@ except ImportError:
 
 import asyncio
 
-try:
-    import mock
-except ImportError:
-    print("Please install mock from PyPI to run tests!")
-    sys.exit(1)
 
 # show deprecation warnings
 warnings.simplefilter("default")

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
     test_suite="mpd.tests",
     tests_require=[
         'tox',
-        'mock',
         'Twisted'
     ],
     cmdclass={

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist = py36,py37,py38,py39,pypy3
 
 [testenv]
-deps = mock
-       coverage
+deps = coverage
        Twisted
 commands = coverage erase
            coverage run -m unittest mpd.tests


### PR DESCRIPTION
A built-in unittest.mock module is available since Python 3.3 that
is a drop-in replacement for the external mock package.  Since Python 2
is not supported, just use that and remove the dependency.