### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ The following features were added:
 -  API documentation to add new commands (see `Future Compatible <https://python-mpd2.readthedocs.io/en/latest/topics/advanced.html#future-compatible>`__)
 -  support for Unicode strings in all commands (optionally in python2,
    default in python3 - see `Unicode Handling <https://python-mpd2.readthedocs.io/en/latest/topics/advanced.html#unicode-handling>`__)
--  configureable timeouts
+-  configurable timeouts
 -  support for `logging <https://python-mpd2.readthedocs.io/en/latest/topics/logging.html>`__
 -  improved support for sticker
 -  improved support for ranges

--- a/doc/generate_command_reference.py
+++ b/doc/generate_command_reference.py
@@ -28,7 +28,7 @@ def get_text(elements, itemize=False):
             'function'
     ] + highlight_elements
     for element in elements:
-        # put "Since MPD version..." in paranthese
+        # put "Since MPD version..." in parenthese
         etree.strip_tags(element, "application")
         for e in element.xpath("footnote/simpara"):
             e.text = "(" + e.text.strip() + ")"

--- a/doc/topics/advanced.rst
+++ b/doc/topics/advanced.rst
@@ -21,7 +21,7 @@ New commands or special handling of commands can be easily implemented.  Use
 Thread-Safety
 -------------
 
-Currently ``MPDClient`` is **NOT** thread-safe. As it use a socket internaly,
+Currently ``MPDClient`` is **NOT** thread-safe. As it use a socket internally,
 only one thread can send or receive at the time.
 
 But ``MPDClient`` can be easily extended to be thread-safe using `locks

--- a/doc/topics/commands.rst
+++ b/doc/topics/commands.rst
@@ -825,7 +825,7 @@ Mounts and neighbors
 
     Multiple storages can be "mounted" together, similar to the mount
     command on many operating systems, but without cooperation from
-    the kernel. No superuser privileges are necessary, beause this
+    the kernel. No superuser privileges are necessary, because this
     mapping exists only inside the MPD process
 
 .. function:: MPDClient.mount(path, uri)

--- a/doc/topics/getting-started.rst
+++ b/doc/topics/getting-started.rst
@@ -64,6 +64,6 @@ by using two element tuple::
      'file: song3.mp3',]
 
 Second element can be omitted. MPD will assumes the biggest possible number then (don't forget the comma!)::
-NOTE: mpd versions between 0.16.8 and 0.17.3 contains a bug, so ommiting doesn't work.
+NOTE: mpd versions between 0.16.8 and 0.17.3 contains a bug, so omitting doesn't work.
 
     >>> client.delete((1,))     # delete all songs, but the first.

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -147,7 +147,7 @@ class MPDClient(MPDClientBase):
 
     #: Indicator of whether there is a pending idle command that was not terminated yet.
     # When in doubt; this is True, thus erring at the side of caution (because
-    # a "noidle" being sent while racing against an incmoing idle notification
+    # a "noidle" being sent while racing against an incoming idle notification
     # does no harm)
     __in_idle = False
 

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -51,7 +51,7 @@ class TestMPDClient(unittest.TestCase):
             # Create a new socket.socket() mock with default attributes,
             # each time we are calling it back (otherwise, it keeps set
             # attributes across calls).
-            # That's probablyy what we want, since reconnecting is like
+            # That's probably what we want, since reconnecting is like
             # reinitializing the entire connection, and so, the mock.
             mock.MagicMock(name="socket.socket")
         )


### PR DESCRIPTION
There are small typos in:
- README.rst
- doc/generate_command_reference.py
- doc/topics/advanced.rst
- doc/topics/commands.rst
- doc/topics/getting-started.rst
- mpd/asyncio.py
- mpd/tests.py

Fixes:
- Should read `probably` rather than `probablyy`.
- Should read `parenthese` rather than `paranthese`.
- Should read `omitting` rather than `ommiting`.
- Should read `internally` rather than `internaly`.
- Should read `incoming` rather than `incmoing`.
- Should read `configurable` rather than `configureable`.
- Should read `because` rather than `beause`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md