### PR TITLE
Python 3.10 fixes

### DIFF
--- a/examples/asyncio_example.py
+++ b/examples/asyncio_example.py
@@ -60,4 +60,4 @@ async def main():
             break
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())

--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -18,6 +18,7 @@ Command lists are currently not supported.
 This module requires Python 3.5.2 or later to run.
 """
 
+import warnings
 import asyncio
 from functools import partial
 from typing import Optional, List, Tuple, Iterable, Callable, Union
@@ -199,10 +200,12 @@ class MPDClient(MPDClientBase):
         self.__rfile = self.__wfile = None
 
     async def connect(self, host, port=6600, loop=None):
+        if loop is not None:
+            warnings.warn("loop passed into MPDClient.connect is ignored, this will become an error", DeprecationWarning)
         if "/" in host:
-            r, w = await asyncio.open_unix_connection(host, loop=loop)
+            r, w = await asyncio.open_unix_connection(host)
         else:
-            r, w = await asyncio.open_connection(host, port, loop=loop)
+            r, w = await asyncio.open_connection(host, port)
         self.__rfile, self.__wfile = r, w
 
         self.__command_queue = asyncio.Queue(maxsize=self.COMMAND_QUEUE_LENGTH)

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -1262,10 +1262,10 @@ class TestAsyncioMPD(unittest.TestCase):
         self.mockserver.expect_exchange([], hello_lines)
 
         self.client = mpd.asyncio.MPDClient()
-        self._await(self.client.connect(TEST_MPD_HOST, TEST_MPD_PORT, loop=self.loop))
+        self._await(self.client.connect(TEST_MPD_HOST, TEST_MPD_PORT))
 
         asyncio.open_connection.assert_called_with(
-            TEST_MPD_HOST, TEST_MPD_PORT, loop=self.loop
+            TEST_MPD_HOST, TEST_MPD_PORT
         )
 
     def __del__(self):


### PR DESCRIPTION
This fixes https://github.com/Mic92/python-mpd2/issues/178, and changes the example to use the more modern asyncio.run idiom which should give better handling of interruptions.

The latter is only in 3.7 (while mpd2 still supports 3.6), but I think that the example doesn't need to be that strict (and 3.6 is about to lose support on the Python side anyway).