### PR TITLE
fixed multiple use of "group" in list command

### DIFF
--- a/mpd/base.py
+++ b/mpd/base.py
@@ -239,12 +239,20 @@ class MPDClientBase(object):
         obj = {}
         for key, value in self._parse_pairs(lines):
             key = key.lower()
-            if lookup_delimiter and not delimiters:
-                delimiters = [key]
+            if lookup_delimiter and key not in delimiters:
+                delimiters = delimiters + [key]
             if obj:
                 if key in delimiters:
-                    yield obj
-                    obj = {}
+                    if lookup_delimiter:
+                        if key in obj:
+                            yield obj
+                            obj = obj.copy()
+                            while delimiters[-1] != key:
+                                obj.pop(delimiters[-1], None)
+                                delimiters.pop()
+                    else:
+                        yield obj
+                        obj = {}
                 elif key in obj:
                     if not isinstance(obj[key], list):
                         obj[key] = [obj[key], value]

--- a/mpd/tests.py
+++ b/mpd/tests.py
@@ -262,6 +262,31 @@ class TestMPDClient(unittest.TestCase):
         self.assertIsNone(self.client.moveoutput("My ALSA Device"))
         self.assertMPDReceived('moveoutput "My ALSA Device"\n')
 
+    def test_list_group(self):
+        self.MPDWillReturn(
+            "AlbumArtist: Kraftwerk\n",
+            "Date: 1970\n",
+            "Album: Tone Float (Unofficial)\n",
+            "Date: 1974\n",
+            "Album: Autobahn\n",
+            "Album: Autobahn (2009 Der Katalog)\n",
+            "OK\n"
+        )
+        grouped_list = self.client.list(
+            "album", "albumartist", "Kraftwerk", "group", "date", "group", "albumartist"
+        )
+        self.assertMPDReceived(
+            'list "album" "albumartist" "Kraftwerk" "group" "date" "group" "albumartist"\n'
+        )
+        self.assertEqual(
+            [
+                {'albumartist': 'Kraftwerk', 'date': '1970', 'album': 'Tone Float (Unofficial)'},
+                {'albumartist': 'Kraftwerk', 'date': '1974', 'album': 'Autobahn'},
+                {'albumartist': 'Kraftwerk', 'date': '1974', 'album': 'Autobahn (2009 Der Katalog)'}
+            ],
+            grouped_list
+        )
+
     def test_client_to_client(self):
         # client to client is at this time in beta!
 


### PR DESCRIPTION
Hi!
This a followup of #186. Here is the output of the example form the issue with the patched version:

```
Python 3.9.9 (main, Nov 28 2021, 10:57:04) 
[GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from mpd import MPDClient
>>> c=MPDClient()
>>> c.connect("localhost", 6600)
>>> c.list("album", "albumartist", "Kraftwerk", "group", "date", "group", "albumartist")
[{'albumartist': 'Kraftwerk', 'date': '1970', 'album': 'Tone Float (Unofficial)'}, {'albumartist': 'Kraftwerk', 'date': '1974', 'album': 'Autobahn'}, {'albumartist': 'Kraftwerk', 'date': '1974', 'album': 'Autobahn (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1975', 'album': 'Radio-Activity'}, {'albumartist': 'Kraftwerk', 'date': '1975', 'album': 'Radio-Activity (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1975', 'album': 'Radio-Aktivität'}, {'albumartist': 'Kraftwerk', 'date': '1975', 'album': 'Radio-Aktivität (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1977', 'album': 'Trans Europa Express'}, {'albumartist': 'Kraftwerk', 'date': '1977', 'album': 'Trans Europa Express (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1977', 'album': 'Trans Europe Express (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1978', 'album': 'Die Mensch-Maschine'}, {'albumartist': 'Kraftwerk', 'date': '1978', 'album': 'Die Mensch-Maschine (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1978', 'album': 'The Man Machine (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1981', 'album': 'Computer World'}, {'albumartist': 'Kraftwerk', 'date': '1981', 'album': 'Computer World (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1981', 'album': 'Computerwelt'}, {'albumartist': 'Kraftwerk', 'date': '1981', 'album': 'Computerwelt (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '1986', 'album': 'Electric Cafe (de)'}, {'albumartist': 'Kraftwerk', 'date': '1986', 'album': 'Electric Cafe (en)'}, {'albumartist': 'Kraftwerk', 'date': '1986', 'album': 'Techno Pop (2009 Der Katalog, English)'}, {'albumartist': 'Kraftwerk', 'date': '1986', 'album': 'Techno Pop (2009 Der Katalog, deutsch)'}, {'albumartist': 'Kraftwerk', 'date': '1991', 'album': 'Die Roboter'}, {'albumartist': 'Kraftwerk', 'date': '1991', 'album': 'The Mix (2009 Der Katalog, English)'}, {'albumartist': 'Kraftwerk', 'date': '1991', 'album': 'The Mix (2009 Der Katalog, deutsch)'}, {'albumartist': 'Kraftwerk', 'date': '1991', 'album': 'The Mix (de)'}, {'albumartist': 'Kraftwerk', 'date': '1991', 'album': 'The Mix (en)'}, {'albumartist': 'Kraftwerk', 'date': '2003', 'album': 'Tour De France (2009 Der Katalog)'}, {'albumartist': 'Kraftwerk', 'date': '2003', 'album': 'Tour De France Soundtracks'}, {'albumartist': 'Kraftwerk', 'date': '2005', 'album': 'Minimum-Maximum'}]
>>> 
```

I tried to match your code style I hope I succeeded :-) 