### PR TITLE
fix unmount command not working

### DIFF
--- a/mpd/base.py
+++ b/mpd/base.py
@@ -387,7 +387,7 @@ class MPDClientBase(object):
         "swap",
         "swapid",
         "toggleoutput",
-        "umount",
+        "unmount",
         "unsubscribe",
         "volume",
     )


### PR DESCRIPTION
MPDClient.unmount is missing, instead MPDClient.umount is found but doesn't work as expected.
```
In [1]: from mpd import MPDClient

In [2]: client = MPDClient()

In [3]: client.connect('192.168.0.187', 6600)

In [4]: client.listmounts()
Out[4]: [{'mount': ''}, {'mount': 'foo', 'storage': 'http://192.168.0.187:9000/media'}]

In [5]: client.unmount('foo')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-034474681c24> in <module>
----> 1 client.unmount('foo')

AttributeError: 'MPDClient' object has no attribute 'unmount'

In [6]: client.umount('foo')
---------------------------------------------------------------------------
CommandError                              Traceback (most recent call last)
<ipython-input-6-eded5c573b51> in <module>
----> 1 client.umount('foo')

/usr/local/lib/python3.7/dist-packages/mpd/base.py in mpd_command(self, *args)
    466     def mpd_command(self, *args):
    467         callback = _create_callback(self, return_value, wrap_result)
--> 468         return wrapper(self, name, args, callback)
    469 
    470     return mpd_command

/usr/local/lib/python3.7/dist-packages/mpd/base.py in _execute(self, command, args, retval)
    529             self._write_command(command, args)
    530             if callable(retval):
--> 531                 return retval()
    532             return retval
    533 

/usr/local/lib/python3.7/dist-packages/mpd/base.py in command_callback()
    451         # command result callback expects response from MPD as iterable lines,
    452         # thus read available lines from socket
--> 453         res = function(self, self._read_lines())
    454         # wrap result in iterator helper if desired
    455         if wrap_result:

/usr/local/lib/python3.7/dist-packages/mpd/base.py in _parse_nothing(self, lines)
    379     )
    380     def _parse_nothing(self, lines):
--> 381         for line in lines:
    382             raise ProtocolError(
    383                 "Got unexpected return value: '{}'".format(", ".join(lines))

/usr/local/lib/python3.7/dist-packages/mpd/base.py in _read_lines(self)
    583 
    584     def _read_lines(self):
--> 585         line = self._read_line()
    586         while line is not None:
    587             yield line

/usr/local/lib/python3.7/dist-packages/mpd/base.py in _read_line(self)
    572         if line.startswith(ERROR_PREFIX):
    573             error = line[len(ERROR_PREFIX) :].strip()
--> 574             raise CommandError(error)
    575         if self._command_list is not None:
    576             if line == NEXT:

CommandError: [5@0] {} unknown command "umount"
```