### PR TITLE
added binarylimit command

### DIFF
--- a/mpd/base.py
+++ b/mpd/base.py
@@ -330,6 +330,7 @@ class MPDClientBase(object):
     @mpd_commands(
         "add",
         "addtagid",
+        "binarylimit",
         "clear",
         "clearerror",
         "cleartagid",


### PR DESCRIPTION
Since protocol version 0.22.4 MPD supports the `binarylimit` command to speed up cover fetching. See: https://github.com/MusicPlayerDaemon/MPD/issues/1038 and https://github.com/MusicPlayerDaemon/MPD/commit/995aafe9cc511430bff7a7a690df70998f4bb025
This pull request enables python-mpd2 to use it.