### PR TITLE
Implement abstract socket support

### DIFF
--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -202,7 +202,9 @@ class MPDClient(MPDClientBase):
     async def connect(self, host, port=6600, loop=None):
         if loop is not None:
             warnings.warn("loop passed into MPDClient.connect is ignored, this will become an error", DeprecationWarning)
-        if "/" in host:
+        if host.startswith("@"):
+            host = "\0" + host[1:]
+        if host.startswith("\0") or "/" in host:
             r, w = await asyncio.open_unix_connection(host)
         else:
             r, w = await asyncio.open_connection(host, port)

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -788,7 +788,9 @@ class MPDClient(MPDClientBase):
                 DeprecationWarning,
             )
             self.timeout = timeout
-        if host.startswith("/"):
+        if host.startswith("@"):
+            host = "\0" + host[1:]
+        if host.startswith(("/", "\0")):
             self._sock = self._connect_unix(host)
         else:
             if port is None:


### PR DESCRIPTION
The `@` prefix is an mpd convention: it is used in `mpd.conf` `bind_to_address` and by libmpdclient (and everything downstream: mpc etc...). It doesn't hurt to be more permissive and accept paths starting with the NUL byte as well, as that's the Linux socket API convention and doesn't violate mpd2's backwards compatibility anyways. 

Regarding backwards compatibility: for `mpd.base`, this should not be a breaking change: `@` is not allowed in hostnames and `connect(host)` only accepts absolute paths. However, this may be a breaking change for `mpd.asyncio` users: the current implementation of `connect(host)` only checks for presence of the path separator `/` in `host`, meaning it accepts relative paths. I purposefully did not change this behavior in order to ensure the PR remains focused on one feature but this does mean that there is potential for backwards incompatibility when connecting to a path relative to cwd with a name starting with `@`. Of course, this is a pretty unlikely edge case, but I thought it'd be worth mentioning.

I did not notice any tests specifically testing `connect()` behavior in `mpd/tests.py` and therefore did not add my own. If I should add a test for this new feature, do let me know.