### PR TITLE
missing import / wrong variable

### DIFF
--- a/mpd/asyncio.py
+++ b/mpd/asyncio.py
@@ -26,7 +26,7 @@ from typing import Optional, List, Tuple, Iterable, Callable, Union
 from mpd.base import HELLO_PREFIX, ERROR_PREFIX, SUCCESS
 from mpd.base import MPDClientBase
 from mpd.base import MPDClient as SyncMPDClient
-from mpd.base import ProtocolError, ConnectionError, CommandError
+from mpd.base import ProtocolError, ConnectionError, CommandError, CommandListError
 from mpd.base import mpd_command_provider
 
 

--- a/mpd/base.py
+++ b/mpd/base.py
@@ -633,7 +633,7 @@ class MPDClient(MPDClientBase):
                     self.disconnect()
                     raise ConnectionError(
                         "Connection lost while reading binary data: "
-                        "expected %d bytes, got %d" % (chunk_size, len(data))
+                        "expected %d bytes, got %d" % (chunk_size, len(value))
                     )
 
                 if self._rbfile.read(1) != b"\n":


### PR DESCRIPTION
Hello,

while experimenting with cythonizing python-mpd2, the compiler found two small issues:
* In asyncio.py, the missing import "CommandListError" is used in line 468.
* In base.py, the variable data is not available in _read_binary and value seems to be the correct one. Propably a c&p error.

Kind Regards
Michael